### PR TITLE
RulerController.mouseExited: add crosshair.push() - this makes sure t…

### DIFF
--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -15,6 +15,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
 
     let openHand = NSCursor.openHand
     let closedHand = NSCursor.closedHand
+    let crosshair = NSCursor.crosshair
 
     var preferencesWindowOpen = false {
         didSet {
@@ -99,6 +100,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
 
     override func mouseExited(with event: NSEvent) {
         openHand.pop()
+        crosshair.push()
     }
 
     override func mouseDown(with event: NSEvent) {


### PR DESCRIPTION
Hi @pascalpp 

The version 2.0.1 has the following behavior on my Mac / Catalina:
1- on app start, the cursor is crosshair outside of ruler views: **good**
2- a click outside of ruler views deactivates the app, and cursor is defined by the active window
3- a click on one of ruler views reactivates the app, but the cursor is arrow
4- moving the cursor outside of ruler views produces not the crosshair, but the open hand: **not good IMO**

My change proposed here contains an additional `crosshair.push()` in `RulerController.mouseExited` which makes sure that in the step 4 above the cursor becomes crosshair.

Best regards @rudifa 