### PR TITLE
add crosshair cursor position readout relative to a reference point

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4102882260712F00F06A10 /* AppDelegate.swift */; };
 		6F41028E2260713100F06A10 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41028C2260713100F06A10 /* MainMenu.xib */; };
 		6F41029F22607DC900F06A10 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
+		9DC872BB23550CF600C455EA /* DebugUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC872BA23550CF600C455EA /* DebugUtil.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -63,6 +64,7 @@
 		6F41028F2260713100F06A10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F4102902260713100F06A10 /* Free_Ruler.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Free_Ruler.entitlements; sourceTree = "<group>"; };
 		6F41029E22607DC900F06A10 /* HorizontalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRule.swift; sourceTree = "<group>"; };
+		9DC872BA23550CF600C455EA /* DebugUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugUtil.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 		6F4102872260712F00F06A10 /* Free Ruler */ = {
 			isa = PBXGroup;
 			children = (
+				9DC872BA23550CF600C455EA /* DebugUtil.swift */,
 				507FED5F2280E13200BD77DC /* Prefs.swift */,
 				50008B6022846FCD001E3EE4 /* Notifications.swift */,
 				6F4102882260712F00F06A10 /* AppDelegate.swift */,
@@ -199,6 +202,7 @@
 				6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */,
 				50D7BEED227D5C810008B95E /* RuleView.swift in Sources */,
 				50D7BEE9227D43270008B95E /* Ruler.swift in Sources */,
+				9DC872BB23550CF600C455EA /* DebugUtil.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Free Ruler/DebugUtil.swift
+++ b/Free Ruler/DebugUtil.swift
@@ -1,0 +1,28 @@
+//
+//  DebugUtil.swift  v.0.2.0
+//  SwiftUtilBiP
+//
+//  Created by Rudolf Farkas on 23.07.19.
+//  Copyright © 2019 Rudolf Farkas. All rights reserved.
+//
+
+import Foundation
+
+extension NSObject {
+    /// Print current class and function names, optionally info
+    ///
+    /// - Note: Printing is enabled by DEBUG constant which is normally absent from release builds.
+    ///
+    /// - Requires: to be called from a subclass of NSObject
+    ///
+    /// - Parameters:
+    ///  - info: information string; a leading "@" will be replaced by the call time
+    ///  - fnc: current function (default value is the caller)
+    func printClassAndFunc(info inf_: String = "", fnc fnc_: String = #function) {
+        #if DEBUG
+        var info = inf_
+        if inf_.first == "@" { info = "\(Date()) \(inf_.dropFirst())"}
+        print("---- \(String(describing: type(of: self))).\(fnc_)", info)
+        #endif
+    }
+}

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -78,6 +78,15 @@ class HorizontalRule: RuleView {
         self.mouseTickX = mouseX - windowX
     }
 
+    func relativeX(mouseTickX: CGFloat) -> CGFloat {
+        if let refLoc = getReferencePoint() {
+            let windowX = self.window?.frame.origin.x ?? 0
+            let correction = refLoc.x - windowX
+            return mouseTickX - correction
+        }
+        return mouseTickX
+    }
+
     func drawMouseTick(_ mouseTickX: CGFloat) {
         let mouseTick = NSBezierPath()
         let height: CGFloat = 40
@@ -94,7 +103,6 @@ class HorizontalRule: RuleView {
     func drawMouseNumber(_ mouseTickX: CGFloat) {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .left
-
         let number = mouseTickX
         let labelWidth: CGFloat = 40
 
@@ -113,7 +121,7 @@ class HorizontalRule: RuleView {
             NSAttributedString.Key.backgroundColor: color.fill,
         ]
 
-        let label = String(Int(number))
+        let label = String(Int(relativeX(mouseTickX: number)))
         label.draw(with: CGRect(x: labelX, y: 20, width: labelWidth, height: 20), options: .usesLineFragmentOrigin, attributes: attrs, context: nil)
 
     }

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -20,6 +20,21 @@ class RuleView: NSView {
         .inVisibleRect,
     ]
 
+    private var referencePoint: NSPoint?
+
+    func setReferencePoint(location: NSPoint) {
+        referencePoint = location
+        drawMouseTick(at: location)
+    }
+
+    func clearReferencePoint() {
+        referencePoint = nil
+    }
+
+    func getReferencePoint() -> NSPoint? {
+        return referencePoint
+    }
+
     override func updateTrackingAreas() {
         if trackingArea != nil {
             removeTrackingArea(trackingArea!)

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -222,6 +222,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     func resetPosition() {
         let frame = getDefaultContentRect(orientation: ruler.orientation)
         rulerWindow.setFrame(frame, display: true)
+        rulerWindow.rule.clearReferencePoint()
     }
 
 }
@@ -249,7 +250,6 @@ extension RulerController {
         // print(ruler.orientation, "onKeyDown")
 
         let shift = event.modifierFlags.contains(.shift)
-
         switch Int(event.keyCode) {
         case kVK_LeftArrow:
             rulerWindow.nudgeLeft(withShift: shift)
@@ -262,6 +262,10 @@ extension RulerController {
             return nil
         case kVK_DownArrow:
             rulerWindow.nudgeDown(withShift: shift)
+            return nil
+        case 47: // "."
+            rulerWindow.rule.setReferencePoint(location: NSEvent.mouseLocation)
+            otherWindow?.rule.setReferencePoint(location: NSEvent.mouseLocation)
             return nil
         default:
             return event

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -79,6 +79,15 @@ class VerticalRule: RuleView {
         self.mouseTickY = mouseY - windowY
     }
 
+    func relativeY(mouseTickY: CGFloat) -> CGFloat {
+        if let refLoc = getReferencePoint() {
+            let windowY = self.window?.frame.origin.y ?? 0
+            let correction = -(refLoc.y - windowY - windowHeight)
+            return mouseTickY - correction
+        }
+        return mouseTickY
+    }
+
     func drawMouseTick(_ mouseTickY: CGFloat) {
         let mouseTick = NSBezierPath()
         let width: CGFloat = 40
@@ -114,7 +123,7 @@ class VerticalRule: RuleView {
             NSAttributedString.Key.backgroundColor: color.fill,
         ]
 
-        let label = String(Int(number))
+        let label = String(Int(relativeY(mouseTickY: number)))
         label.draw(with: CGRect(x: 5, y: windowHeight - labelY, width: 40, height: 20), options: .usesLineFragmentOrigin, attributes: attrs, context: nil)
 
     }


### PR DESCRIPTION
@pascalpp Hello Pascal, I have here a working proposal for a new feature: 
**crosshair cursor readout relative to a reference point set by the user**.

It works like this: 
- user moves the crosshair cursor to the desired reference point and taps on key "." to set it.
- henceforth the x, y readout values are relative to the reference point
- he (she?) can set a new reference point at any time
- the reference point remains active even if rulers are moved
- the reference point is cleared by cmd-R

Please let me know what do you think of this feature.

PS. While I removed my debug printouts from the commit, I left in my debugging tool `func printClassAndFunc`, which you might find useful for tracking function calls and data during test runs.
You just insert lines like these
```
       printClassAndFunc()
       printClassAndFunc(info: "mouseTickY=\(mouseTickY) label=\(label)")
```

@rudifa 