### PR TITLE
Use american spelling for millimeters in base

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -17,7 +17,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let crosshair = NSCursor.crosshair
 
     @IBOutlet weak var pixelsMenuItem: NSMenuItem!
-    @IBOutlet weak var millimetresMenuItem: NSMenuItem!
+    @IBOutlet weak var millimetersMenuItem: NSMenuItem!
     @IBOutlet weak var inchesMenuItem: NSMenuItem!
     
     @IBOutlet weak var floatRulersMenuItem: NSMenuItem!
@@ -69,7 +69,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func updateUnitMenu() {
         pixelsMenuItem?.state      = prefs.unit == .pixels ? .on : .off
-        millimetresMenuItem?.state = prefs.unit == .millimetres ? .on : .off
+        millimetersMenuItem?.state = prefs.unit == .millimeters ? .on : .off
         inchesMenuItem?.state      = prefs.unit == .inches ? .on : .off
     }
 
@@ -125,7 +125,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         prefs.unit = .pixels
     }
     @IBAction func setUnitMillimetres(_ sender: Any) {
-        prefs.unit = .millimetres
+        prefs.unit = .millimeters
     }
     @IBAction func setUnitInches(_ sender: Any) {
         prefs.unit = .inches

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -207,8 +207,8 @@
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Zoom" keyEquivalent="z" id="R4o-n2-Eq4">
-                                <modifierMask key="keyEquivalentModifierMask" control="YES"/>
+                            <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
                                 </connections>

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -18,7 +18,7 @@
                 <outlet property="floatRulersMenuItem" destination="GDK-AC-uC8" id="552-nT-5F2"/>
                 <outlet property="groupRulersMenuItem" destination="7Ga-Fb-LLc" id="WrL-X9-6QE"/>
                 <outlet property="inchesMenuItem" destination="lt1-Hj-2TR" id="yV0-oN-4bC"/>
-                <outlet property="millimetresMenuItem" destination="B6Y-Hi-AkN" id="9Cc-tZ-RRZ"/>
+                <outlet property="millimetersMenuItem" destination="B6Y-Hi-AkN" id="9Cc-tZ-RRZ"/>
                 <outlet property="pixelsMenuItem" destination="pYR-Ba-kKi" id="Wus-JK-rs3"/>
                 <outlet property="rulerShadowMenuItem" destination="a8D-hN-A59" id="FZM-pS-71y"/>
             </connections>
@@ -146,7 +146,7 @@
                                     <action selector="setUnitPixels:" target="Voe-Tx-rLC" id="CKT-cD-v5a"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Millimetres" id="B6Y-Hi-AkN">
+                            <menuItem title="Millimeters" id="B6Y-Hi-AkN">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="setUnitMillimetres:" target="Voe-Tx-rLC" id="jOc-Pv-TID"/>
@@ -207,8 +207,8 @@
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Zoom" id="R4o-n2-Eq4">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Zoom" keyEquivalent="z" id="R4o-n2-Eq4">
+                                <modifierMask key="keyEquivalentModifierMask" control="YES"/>
                                 <connections>
                                     <action selector="performZoom:" target="-1" id="DIl-cC-cCs"/>
                                 </connections>

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -40,7 +40,7 @@ class HorizontalRule: RuleView {
         let tinyTicks: Int?
         
         switch prefs.unit {
-        case .millimetres:
+        case .millimeters:
             tickScale = screen?.dpmm.width ?? NSScreen.defaultDpmm
             textScale = 1
             largeTicks = 10
@@ -149,7 +149,7 @@ class HorizontalRule: RuleView {
 
         let label: String
         switch prefs.unit {
-        case .millimetres:
+        case .millimeters:
             label = String(format: "%.1f", number / (screen?.dpmm.width ?? NSScreen.defaultDpmm))
         case .inches:
             label = String(format: "%.3f", number / (screen?.dpi.width ?? NSScreen.defaultDpi))

--- a/Free Ruler/Prefs.swift
+++ b/Free Ruler/Prefs.swift
@@ -15,7 +15,7 @@ let prefs = Prefs.shared
 
 @objc enum Unit: Int {
     case pixels
-    case millimetres
+    case millimeters
     case inches
 }
 

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -42,7 +42,7 @@ class VerticalRule: RuleView {
         let tinyTicks: Int?
         
         switch prefs.unit {
-        case .millimetres:
+        case .millimeters:
             tickScale = screen?.dpmm.width ?? NSScreen.defaultDpmm
             textScale = 1
             largeTicks = 10
@@ -151,7 +151,7 @@ class VerticalRule: RuleView {
 
         let label: String
         switch prefs.unit {
-        case .millimetres:
+        case .millimeters:
             label = String(format: "%.1f", number / (screen?.dpmm.width ?? NSScreen.defaultDpmm))
         case .inches:
             label = String(format: "%.3f", number / (screen?.dpi.width ?? NSScreen.defaultDpi))

--- a/Free Ruler/de.lproj/MainMenu.strings
+++ b/Free Ruler/de.lproj/MainMenu.strings
@@ -128,7 +128,7 @@
 /* Class = "NSMenuItem"; title = "Pixels"; ObjectID = "pYR-Ba-kKi"; */
 "pYR-Ba-kKi.title" = "Pixel";
 
-/* Class = "NSMenuItem"; title = "Millimetres"; ObjectID = "B6Y-Hi-AkN"; */
+/* Class = "NSMenuItem"; title = "Millimeters"; ObjectID = "B6Y-Hi-AkN"; */
 "B6Y-Hi-AkN.title" = "Millimeter";
 
 /* Class = "NSMenuItem"; title = "Inches"; ObjectID = "lt1-Hj-2TR"; */


### PR DESCRIPTION
Prefer to use american spelling conventions in the base localization. We could use a localization for en_GB.