### PR TITLE
Unit improvements

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -19,7 +19,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var pixelsMenuItem: NSMenuItem!
     @IBOutlet weak var millimetersMenuItem: NSMenuItem!
     @IBOutlet weak var inchesMenuItem: NSMenuItem!
-    
+    @IBOutlet weak var cycleUnitsMenuItem: NSMenuItem!
+
     @IBOutlet weak var floatRulersMenuItem: NSMenuItem!
     @IBOutlet weak var groupRulersMenuItem: NSMenuItem!
     @IBOutlet weak var rulerShadowMenuItem: NSMenuItem!
@@ -47,6 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         observers = [
             prefs.observe(\Prefs.unit, options: .new) { prefs, changed in
                 self.updateUnitMenu()
+                self.redrawRulers()
             },
             prefs.observe(\Prefs.floatRulers, options: .new) { prefs, changed in
                 self.updateFloatRulersMenuItem()
@@ -71,6 +73,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pixelsMenuItem?.state      = prefs.unit == .pixels ? .on : .off
         millimetersMenuItem?.state = prefs.unit == .millimeters ? .on : .off
         inchesMenuItem?.state      = prefs.unit == .inches ? .on : .off
+    }
+
+    func redrawRulers() {
+        for ruler in rulers {
+            ruler.rulerWindow.rule.setNeedsDisplay(ruler.rulerWindow.rule.visibleRect)
+        }
     }
 
     func updateFloatRulersMenuItem() {
@@ -130,7 +138,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBAction func setUnitInches(_ sender: Any) {
         prefs.unit = .inches
     }
-    
+    @IBAction func cycleUnits(_ sender: Any) {
+        switch prefs.unit {
+        case .pixels:
+            prefs.unit = .millimeters
+        case .millimeters:
+            prefs.unit = .inches
+        case .inches:
+            prefs.unit = .pixels
+        }
+    }
+
     @IBAction func toggleFloatRulers(_ sender: Any) {
         prefs.floatRulers = !prefs.floatRulers
     }

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -246,11 +246,5 @@
             </items>
             <point key="canvasLocation" x="-147" y="125"/>
         </menu>
-        <menuItem title="Group Rulers" state="on" keyEquivalent="g" id="7SO-Lm-Ylr">
-            <modifierMask key="keyEquivalentModifierMask"/>
-            <connections>
-                <action selector="toggleGroupRulers:" target="Voe-Tx-rLC" id="RkN-cz-hMe"/>
-            </connections>
-        </menuItem>
     </objects>
 </document>

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -15,6 +15,7 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Free_Ruler" customModuleProvider="target">
             <connections>
                 <outlet property="alignRulersMenuItem" destination="iKV-uW-hwy" id="KQ1-Wu-ShT"/>
+                <outlet property="cycleUnitsMenuItem" destination="2nm-aL-kZd" id="cec-5d-z3z"/>
                 <outlet property="floatRulersMenuItem" destination="GDK-AC-uC8" id="552-nT-5F2"/>
                 <outlet property="groupRulersMenuItem" destination="7Ga-Fb-LLc" id="WrL-X9-6QE"/>
                 <outlet property="inchesMenuItem" destination="lt1-Hj-2TR" id="yV0-oN-4bC"/>
@@ -156,6 +157,13 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="setUnitInches:" target="Voe-Tx-rLC" id="Apf-6P-Oz8"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="tK2-3l-lAd"/>
+                            <menuItem title="Cycle Units" keyEquivalent="u" id="2nm-aL-kZd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="cycleUnits:" target="Voe-Tx-rLC" id="jzB-to-aha"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Free Ruler/FreeRuler.help/Contents/Resources/English.lproj/FreeRuler.html
+++ b/Free Ruler/FreeRuler.help/Contents/Resources/English.lproj/FreeRuler.html
@@ -27,6 +27,7 @@
     <tr><th></th><th>G</th><td>Group/ungroup rulers</td></tr>
     <tr><th></th><th>S</th><td>Show/hide ruler shadows</td></tr>
     <tr><th></th><th>O</th><td>Orient rulers at mouse location</td></tr>
+    <tr><th></th><th>U</th><td>Cycle units: pixels, millimeters, and inches</td></tr>
     <tr><th>⌘</th><th>R</th><td>Reset ruler positions to default</td></tr>
     <tr><th>⌘</th><th>,</th><td>Open Preferences</td></tr>
   </tbody>

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -12,10 +12,6 @@ class HorizontalRule: RuleView {
         }
     }
 
-    var windowWidth: CGFloat {
-        return self.window?.frame.width ?? 0
-    }
-
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
 
@@ -109,11 +105,16 @@ class HorizontalRule: RuleView {
         color.ticks.setStroke()
         path.stroke()
 
+        if mouseTickX < 0 || mouseTickX > 20 {
+            drawUnitLabel()
+        }
+
         // Draw the MouseTick & number
-        if showMouseTick && mouseTickX > 0 && mouseTickX < windowWidth {
+        if showMouseTick && mouseTickX > 0 && mouseTickX < self.windowWidth {
             drawMouseTick(mouseTickX)
             drawMouseNumber(mouseTickX)
         }
+
     }
 
     override func drawMouseTick(at mouseLoc: NSPoint) {
@@ -136,39 +137,57 @@ class HorizontalRule: RuleView {
     }
 
     func drawMouseNumber(_ mouseTickX: CGFloat) {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = .left
-
         let number = mouseTickX
-        let labelWidth: CGFloat = 40
+        let width = self.frame.width
+        let height = self.frame.height
+        let labelOffset: CGFloat = 5
 
-        var labelX = number + 5 // 3px padding from the line
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .center
 
-        if labelX + labelWidth > windowWidth {
-            // Switch to the left of the tick
-            labelX = number - labelWidth - 5
-            paragraphStyle.alignment = .right
-        }
-
-        let attrs = [
+        let attributes = [
             NSAttributedString.Key.font: NSFont(name: "HelveticaNeue", size: 10)!,
             NSAttributedString.Key.paragraphStyle: paragraphStyle,
             NSAttributedString.Key.foregroundColor: color.mouseNumber,
-            NSAttributedString.Key.backgroundColor: color.fill,
         ]
 
-        let label: String
-        switch prefs.unit {
-        case .millimeters:
-            label = String(format: "%.1f", number / (screen?.dpmm.width ?? NSScreen.defaultDpmm))
-        case .inches:
-            label = String(format: "%.3f", number / (screen?.dpi.width ?? NSScreen.defaultDpi))
-        default:
-            label = String(Int(number))
-        }
-        
-        label.draw(with: CGRect(x: labelX, y: 20, width: labelWidth, height: 20), options: .usesLineFragmentOrigin, attributes: attrs, context: nil)
+        let mouseNumber = self.getMouseNumberLabel(number)
+        let label = NSAttributedString(string: mouseNumber, attributes: attributes)
+        let labelSize = label.size()
 
+        let rightPosition = number + labelOffset;
+        let leftPosition = number - labelOffset - labelSize.width
+        let enoughRoomToTheRight = rightPosition + labelSize.width < width - labelOffset
+        let labelX = enoughRoomToTheRight ? rightPosition : leftPosition
+
+        let labelRect = CGRect(x: labelX, y: height - labelSize.height, width: labelSize.width, height: labelSize.height)
+
+        label.draw(
+            with: labelRect,
+            context: nil
+        )
+    }
+
+    func drawUnitLabel() {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .left
+
+        let attributes = [
+            NSAttributedString.Key.font: NSFont(name: "HelveticaNeue", size: 10)!,
+            NSAttributedString.Key.paragraphStyle: paragraphStyle,
+            NSAttributedString.Key.foregroundColor: color.ticks,
+        ]
+
+        let unitlabel = self.getUnitLabel()
+        let label = NSAttributedString(string: unitlabel, attributes: attributes)
+        let height = self.frame.height
+        let labelSize = label.size()
+        let labelRect = CGRect(x: 10, y: height - labelSize.height, width: labelSize.width, height: labelSize.height)
+
+        label.draw(
+            with: labelRect,
+            context: nil
+        )
     }
 
 }

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -25,12 +25,14 @@ class HorizontalRule: RuleView {
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
+        paragraphStyle.lineHeightMultiple = 1
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont(name: "HelveticaNeue", size: 10)!,
             .paragraphStyle: paragraphStyle,
             .foregroundColor: color.numbers
         ]
 
+        let width = dirtyRect.width
         let path = NSBezierPath()
         let tickScale: CGFloat
         let textScale: Int
@@ -63,18 +65,26 @@ class HorizontalRule: RuleView {
             tinyTicks = nil
         }
 
+        let labelWidth: CGFloat = 50
+        let labelHeight: CGFloat = 20
+        let labelOffset: CGFloat = 13 // offset of label from bottom edge of ruler
+
         // substract two so ticks don't overlap with border
         // subtract from this range so width var is accurate
-        for i in 1...Int((dirtyRect.width - 2) / tickScale) {
+        for i in 1...Int((width - 2) / tickScale) {
             let pos = CGFloat(i) * tickScale
             if i.isMultiple(of: largeTicks) {
                 path.move(to: CGPoint(x: pos, y: 1))
                 path.line(to: CGPoint(x: pos, y: 10))
 
                 let label = String(i / textScale)
+                let labelX: CGFloat = pos - (labelWidth / 2) + 0.5 // half-pixel nudge /shrug
+                let labelY: CGFloat = labelOffset
+                let labelRect = CGRect(x: labelX, y: labelY, width: labelWidth, height: labelHeight)
+                // labelRect.frame() // for debugging
+
                 label.draw(
-                    with: CGRect(x: pos - 20, y: 3, width: 40, height: 20),
-                    options: .usesLineFragmentOrigin,
+                    with: labelRect,
                     attributes: attrs,
                     context: nil
                 )

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -21,7 +21,6 @@ class HorizontalRule: RuleView {
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
-        paragraphStyle.lineHeightMultiple = 1
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont(name: "HelveticaNeue", size: 10)!,
             .paragraphStyle: paragraphStyle,
@@ -64,6 +63,7 @@ class HorizontalRule: RuleView {
         let labelWidth: CGFloat = 50
         let labelHeight: CGFloat = 20
         let labelOffset: CGFloat = 13 // offset of label from bottom edge of ruler
+        // TODO: refactor this to use label.size() logic (see func drawUnitLabel)
 
         // substract two so ticks don't overlap with border
         // subtract from this range so width var is accurate

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -77,8 +77,7 @@ class HorizontalRule: RuleView {
                 let labelX: CGFloat = pos - (labelWidth / 2) + 0.5 // half-pixel nudge /shrug
                 let labelY: CGFloat = labelOffset
                 let labelRect = CGRect(x: labelX, y: labelY, width: labelWidth, height: labelHeight)
-                // labelRect.frame() // for debugging
-
+                
                 label.draw(
                     with: labelRect,
                     attributes: attrs,

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -104,7 +104,7 @@ class HorizontalRule: RuleView {
         color.ticks.setStroke()
         path.stroke()
 
-        if mouseTickX < 0 || mouseTickX > 20 {
+        if !showMouseTick || mouseTickX < 0 || mouseTickX > 26 {
             drawUnitLabel()
         }
 

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -67,11 +67,11 @@ class RuleView: NSView {
     func getUnitLabel() -> String {
         switch prefs.unit {
         case .pixels:
-            return "PX"
+            return "px"
         case .millimeters:
-            return "MM"
+            return "mm"
         case .inches:
-            return "IN"
+            return "in"
         }
     }
 

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -41,6 +41,14 @@ class RuleView: NSView {
         fatalError("RuleView subclass must override drawMouseTick method.")
     }
 
+    var windowWidth: CGFloat {
+        return self.window?.frame.width ?? 0
+    }
+
+    var windowHeight: CGFloat {
+        return self.window?.frame.height ?? 0
+    }
+
     var showMouseTick: Bool = true {
         didSet {
             if showMouseTick != oldValue {
@@ -54,6 +62,28 @@ class RuleView: NSView {
             return nil
         }
         return NSScreen.screens.first { $0.frame.contains(window.convertToScreen(frame).origin) }
+    }
+
+    func getUnitLabel() -> String {
+        switch prefs.unit {
+        case .pixels:
+            return "PX"
+        case .millimeters:
+            return "MM"
+        case .inches:
+            return "IN"
+        }
+    }
+
+    func getMouseNumberLabel(_ number: CGFloat) -> String {
+        switch prefs.unit {
+        case .pixels:
+            return String(format: "%d", Int(number))
+        case .millimeters:
+            return String(format: "%.1f", number / (screen?.dpmm.width ?? NSScreen.defaultDpmm))
+        case .inches:
+            return String(format: "%.3f", number / (screen?.dpi.width ?? NSScreen.defaultDpi))
+        }
     }
 
 }
@@ -84,3 +114,22 @@ public extension NSScreen {
     }
     
 }
+
+//public extension CGRect {
+//
+//    func verticalCenteredRectForString(string:NSString,withAttributes attributes : [String:AnyObject])->CGRect {
+//        let size = string.sizeWithAttributes(attributes)
+//        return CGRectMake(self.origin.x, self.origin.y + (self.size.height-size.height)/2.0 , self.size.width, size.height)
+//    }
+//
+//}
+
+
+//public extension String {
+
+//    func drawVerticallyCentered(in rect: CGRect, withAttributes attributes: [NSAttributedStringKey : Any]? = nil) {
+//        let size = self.size(withAttributes: attributes)
+//        let centeredRect = CGRect(x: rect.origin.x, y: rect.origin.y + (rect.size.height-size.height)/2.0, width: rect.size.width, height: size.height)
+//        self.draw(in: centeredRect, withAttributes: attributes)
+//    }
+//}

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -114,22 +114,3 @@ public extension NSScreen {
     }
     
 }
-
-//public extension CGRect {
-//
-//    func verticalCenteredRectForString(string:NSString,withAttributes attributes : [String:AnyObject])->CGRect {
-//        let size = string.sizeWithAttributes(attributes)
-//        return CGRectMake(self.origin.x, self.origin.y + (self.size.height-size.height)/2.0 , self.size.width, size.height)
-//    }
-//
-//}
-
-
-//public extension String {
-
-//    func drawVerticallyCentered(in rect: CGRect, withAttributes attributes: [NSAttributedStringKey : Any]? = nil) {
-//        let size = self.size(withAttributes: attributes)
-//        let centeredRect = CGRect(x: rect.origin.x, y: rect.origin.y + (rect.size.height-size.height)/2.0, width: rect.size.width, height: size.height)
-//        self.draw(in: centeredRect, withAttributes: attributes)
-//    }
-//}

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -79,7 +79,6 @@ class VerticalRule: RuleView {
                 let labelX = width - labelWidth - labelOffset
                 let labelY = height - pos - (textHeight / 2)
                 let labelRect = CGRect(x: labelX, y: labelY, width: labelWidth, height: labelHeight)
-                // labelRect.frame() // for debugging
 
                 label.draw(
                     with: labelRect,

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -25,6 +25,7 @@ class VerticalRule: RuleView {
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .right
+        paragraphStyle.lineHeightMultiple = 1
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont(name: "HelveticaNeue", size: 10)!,
             .paragraphStyle: paragraphStyle,
@@ -65,6 +66,11 @@ class VerticalRule: RuleView {
             tinyTicks = nil
         }
 
+        let labelWidth: CGFloat = 50
+        let labelHeight: CGFloat = 20
+        let labelOffset: CGFloat = 13 // offset of label from right edge of ruler
+        let textHeight: CGFloat = 8   // height of text, used to center the label next to the tick
+
         // substract two so ticks don't overlap with border
         // substract from this range so we can use the height var for position calculations
         for i in 1...Int((height - 2) / tickScale) {
@@ -74,9 +80,13 @@ class VerticalRule: RuleView {
                 path.line(to: CGPoint(x: width - 10, y: height - pos))
 
                 let label = String(i / textScale)
+                let labelX = width - labelWidth - labelOffset
+                let labelY = height - pos - (textHeight / 2)
+                let labelRect = CGRect(x: labelX, y: labelY, width: labelWidth, height: labelHeight)
+                // labelRect.frame() // for debugging
+
                 label.draw(
-                    with: CGRect(x: 3, y: height - pos - 13.5, width: 24, height: 20),
-                    options: .usesLineFragmentOrigin,
+                    with: labelRect,
                     attributes: attrs,
                     context: nil
                 )
@@ -152,14 +162,21 @@ class VerticalRule: RuleView {
         let label: String
         switch prefs.unit {
         case .millimeters:
-            label = String(format: "%.1f", number / (screen?.dpmm.width ?? NSScreen.defaultDpmm))
+            label = String(format: "%.1f  ", number / (screen?.dpmm.width ?? NSScreen.defaultDpmm))
         case .inches:
-            label = String(format: "%.3f", number / (screen?.dpi.width ?? NSScreen.defaultDpi))
+            label = String(format: "%.3f  ", number / (screen?.dpi.width ?? NSScreen.defaultDpi))
         default:
-            label = String(Int(number))
+            label = String(format: "%d  ", Int(number))
         }
 
-        label.draw(with: CGRect(x: 5, y: windowHeight - labelY, width: 40, height: 20), options: .usesLineFragmentOrigin, attributes: attrs, context: nil)
+        let labeRect = CGRect(x: 5, y: windowHeight - labelY, width: 40, height: 20)
+
+        label.draw(
+            with: labeRect,
+            options: .usesLineFragmentOrigin,
+            attributes: attrs,
+            context: nil
+        )
 
     }
 

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -106,7 +106,7 @@ class VerticalRule: RuleView {
         color.ticks.setStroke()
         path.stroke()
 
-        if self.windowHeight - mouseTickY < 0 || windowHeight - mouseTickY > 18 {
+        if !showMouseTick || self.windowHeight - mouseTickY < 0 || windowHeight - mouseTickY > 18 {
             drawUnitLabel()
         }
 

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -106,7 +106,7 @@ class VerticalRule: RuleView {
         color.ticks.setStroke()
         path.stroke()
 
-        if self.windowHeight - mouseTickY < 0 || windowHeight - mouseTickY > 10 {
+        if self.windowHeight - mouseTickY < 0 || windowHeight - mouseTickY > 18 {
             drawUnitLabel()
         }
 

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -21,7 +21,6 @@ class VerticalRule: RuleView {
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .right
-        paragraphStyle.lineHeightMultiple = 1
         let attrs: [NSAttributedString.Key: Any] = [
             .font: NSFont(name: "HelveticaNeue", size: 10)!,
             .paragraphStyle: paragraphStyle,
@@ -66,6 +65,7 @@ class VerticalRule: RuleView {
         let labelHeight: CGFloat = 20
         let labelOffset: CGFloat = 13 // offset of label from right edge of ruler
         let textHeight: CGFloat = 8   // height of text, used to center the label next to the tick
+        // TODO: refactor this to use label.size() logic (see func drawUnitLabel)
 
         // substract two so ticks don't overlap with border
         // substract from this range so we can use the height var for position calculations

--- a/Free Ruler/de.lproj/MainMenu.strings
+++ b/Free Ruler/de.lproj/MainMenu.strings
@@ -133,3 +133,6 @@
 
 /* Class = "NSMenuItem"; title = "Inches"; ObjectID = "lt1-Hj-2TR"; */
 "lt1-Hj-2TR.title" = "Inch";
+
+/* Class = "NSMenuItem"; title = "Cycle Units"; ObjectID = "2nm-aL-kZd"; */
+"2nm-aL-kZd.title" = "Einheiten Durchlaufen";

--- a/Free Ruler/de.lproj/MainMenu.strings
+++ b/Free Ruler/de.lproj/MainMenu.strings
@@ -132,7 +132,7 @@
 "B6Y-Hi-AkN.title" = "Millimeter";
 
 /* Class = "NSMenuItem"; title = "Inches"; ObjectID = "lt1-Hj-2TR"; */
-"lt1-Hj-2TR.title" = "Inch";
+"lt1-Hj-2TR.title" = "Zoll";
 
 /* Class = "NSMenuItem"; title = "Cycle Units"; ObjectID = "2nm-aL-kZd"; */
-"2nm-aL-kZd.title" = "Einheiten Durchlaufen";
+"2nm-aL-kZd.title" = "Nächste Einheit auswählen";

--- a/Free Ruler/fi.lproj/MainMenu.strings
+++ b/Free Ruler/fi.lproj/MainMenu.strings
@@ -135,4 +135,4 @@
 "lt1-Hj-2TR.title" = "Tuumat";
 
 /* Class = "NSMenuItem"; title = "Cycle Units"; ObjectID = "2nm-aL-kZd"; */
-"2nm-aL-kZd.title" = "Vaihda Yksikköä";
+"2nm-aL-kZd.title" = "Vaihda yksikköä";

--- a/Free Ruler/fi.lproj/MainMenu.strings
+++ b/Free Ruler/fi.lproj/MainMenu.strings
@@ -133,3 +133,6 @@
 
 /* Class = "NSMenuItem"; title = "Inches"; ObjectID = "lt1-Hj-2TR"; */
 "lt1-Hj-2TR.title" = "Tuumat";
+
+/* Class = "NSMenuItem"; title = "Cycle Units"; ObjectID = "2nm-aL-kZd"; */
+"2nm-aL-kZd.title" = "Vaihda Yksiköitä";

--- a/Free Ruler/fi.lproj/MainMenu.strings
+++ b/Free Ruler/fi.lproj/MainMenu.strings
@@ -135,4 +135,4 @@
 "lt1-Hj-2TR.title" = "Tuumat";
 
 /* Class = "NSMenuItem"; title = "Cycle Units"; ObjectID = "2nm-aL-kZd"; */
-"2nm-aL-kZd.title" = "Vaihda Yksiköitä";
+"2nm-aL-kZd.title" = "Vaihda Yksikköä";

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A ruler application for Mac OS X
 ### Features
 
 - Horizontal and vertical rulers.
-- Pixel units.
+- Choose from units: pixels, millimeters, or inches (press U to cycle).
 - Float rulers above other applications (press F to toggle).
 - Move windows independently or as a group (press G to toggle).
 - Show or hide the shadow behind rulers (press S to toggle).


### PR DESCRIPTION
- adds a Cycle Units menu command with shortcut `U`
- adds unit labels in the ruler for `PX`, `MM`, and `IN`
- improves mouse tick drawing code

![image](https://user-images.githubusercontent.com/1355312/106228795-1c355280-61ba-11eb-8186-58894c2adffd.png)

![image](https://user-images.githubusercontent.com/1355312/106228814-235c6080-61ba-11eb-9914-d54eec178928.png)

![image](https://user-images.githubusercontent.com/1355312/106228838-33744000-61ba-11eb-9955-f66f5eb7938a.png)

![image](https://user-images.githubusercontent.com/1355312/106228853-3c651180-61ba-11eb-81b2-4616905ea767.png)
