### PR TITLE
add crosshair cursor position readout relative to a reference point

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4102882260712F00F06A10 /* AppDelegate.swift */; };
 		6F41028E2260713100F06A10 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41028C2260713100F06A10 /* MainMenu.xib */; };
 		6F41029F22607DC900F06A10 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
+		9DC872BB23550CF600C455EA /* DebugUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC872BA23550CF600C455EA /* DebugUtil.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -69,6 +70,7 @@
 		8F629823243003EA004F9099 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		8F629825243003F6004F9099 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/PreferencesController.xib; sourceTree = "<group>"; };
 		8F629828243003FF004F9099 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/PreferencesController.strings; sourceTree = "<group>"; };
+		9DC872BA23550CF600C455EA /* DebugUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugUtil.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -101,6 +103,7 @@
 		6F4102872260712F00F06A10 /* Free Ruler */ = {
 			isa = PBXGroup;
 			children = (
+				9DC872BA23550CF600C455EA /* DebugUtil.swift */,
 				50FC527D25BF326800B84228 /* FreeRuler.help */,
 				507FED5F2280E13200BD77DC /* Prefs.swift */,
 				50008B6022846FCD001E3EE4 /* Notifications.swift */,
@@ -209,6 +212,7 @@
 				6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */,
 				50D7BEED227D5C810008B95E /* RuleView.swift in Sources */,
 				50D7BEE9227D43270008B95E /* Ruler.swift in Sources */,
+				9DC872BB23550CF600C455EA /* DebugUtil.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Free Ruler/DebugUtil.swift
+++ b/Free Ruler/DebugUtil.swift
@@ -1,0 +1,31 @@
+//
+//  DebugUtil.swift  v.0.2.0
+//  SwiftUtilBiP
+//
+//  Created by Rudolf Farkas on 23.07.19.
+//  Copyright © 2019 Rudolf Farkas. All rights reserved.
+//
+
+import Foundation
+
+extension NSObject {
+    /// Print current class and function names, optionally info
+    ///
+    /// - Example:
+    ///     printClassAndFunc(info: "mouseTickY=\(mouseTickY) label=\(label)")
+    ///
+    /// - Note: Printing is enabled by DEBUG constant which is normally absent from release builds.
+    ///
+    /// - Requires: to be called from a subclass of NSObject
+    ///
+    /// - Parameters:
+    ///  - info: information string; a leading "@" will be replaced by the call time
+    ///  - fnc: current function (default value is the caller)
+    func printClassAndFunc(info inf_: String = "", fnc fnc_: String = #function) {
+        #if DEBUG
+        var info = inf_
+        if inf_.first == "@" { info = "\(Date()) \(inf_.dropFirst())"}
+        print("---- \(String(describing: type(of: self))).\(fnc_)", info)
+        #endif
+    }
+}

--- a/Free Ruler/FreeRuler.help/Contents/Resources/English.lproj/FreeRuler.html
+++ b/Free Ruler/FreeRuler.help/Contents/Resources/English.lproj/FreeRuler.html
@@ -28,6 +28,7 @@
     <tr><th></th><th>S</th><td>Show/hide ruler shadows</td></tr>
     <tr><th></th><th>O</th><td>Orient rulers at mouse location</td></tr>
     <tr><th></th><th>U</th><td>Cycle units: pixels, millimeters, and inches</td></tr>
+    <tr><th></th><th>.</th><td>Set/unset the origin at cursor `+' location</td></tr>
     <tr><th>⌘</th><th>R</th><td>Reset ruler positions to default</td></tr>
     <tr><th>⌘</th><th>,</th><td>Open Preferences</td></tr>
   </tbody>

--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -35,7 +35,7 @@ class HorizontalRule: RuleView {
         let mediumTicks: Int
         let smallTicks: Int
         let tinyTicks: Int?
-        
+
         switch prefs.unit {
         case .millimeters:
             tickScale = screen?.dpmm.width ?? NSScreen.defaultDpmm
@@ -77,7 +77,7 @@ class HorizontalRule: RuleView {
                 let labelX: CGFloat = pos - (labelWidth / 2) + 0.5 // half-pixel nudge /shrug
                 let labelY: CGFloat = labelOffset
                 let labelRect = CGRect(x: labelX, y: labelY, width: labelWidth, height: labelHeight)
-                
+
                 label.draw(
                     with: labelRect,
                     attributes: attrs,
@@ -122,6 +122,15 @@ class HorizontalRule: RuleView {
         self.mouseTickX = mouseX - windowX
     }
 
+    func relativeX(mouseTickX: CGFloat) -> CGFloat {
+        if let refLoc = getReferencePoint() {
+            let windowX = self.window?.frame.origin.x ?? 0
+            let correction = refLoc.x - windowX
+            return mouseTickX - correction
+        }
+        return mouseTickX
+    }
+
     func drawMouseTick(_ mouseTickX: CGFloat) {
         let mouseTick = NSBezierPath()
         let height: CGFloat = 40
@@ -150,7 +159,7 @@ class HorizontalRule: RuleView {
             NSAttributedString.Key.foregroundColor: color.mouseNumber,
         ]
 
-        let mouseNumber = self.getMouseNumberLabel(number)
+        let mouseNumber = self.getMouseNumberLabel(relativeX(mouseTickX: number))
         let label = NSAttributedString(string: mouseNumber, attributes: attributes)
         let labelSize = label.size()
 

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -20,6 +20,26 @@ class RuleView: NSView {
         .inVisibleRect,
     ]
 
+    private var referencePoint: NSPoint?
+
+    func flipReferencePoint(location: NSPoint) {
+        referencePoint = referencePoint == nil ? location : nil
+        drawMouseTick(at: location)
+    }
+
+    func setReferencePoint(location: NSPoint) {
+        referencePoint = location
+        drawMouseTick(at: location)
+    }
+
+    func clearReferencePoint() {
+        referencePoint = nil
+    }
+
+    func getReferencePoint() -> NSPoint? {
+        return referencePoint
+    }
+
     override func updateTrackingAreas() {
         if trackingArea != nil {
             removeTrackingArea(trackingArea!)

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -263,6 +263,10 @@ extension RulerController {
         case kVK_DownArrow:
             rulerWindow.nudgeDown(withShift: shift)
             return nil
+        case 47: // "."
+            rulerWindow.rule.flipReferencePoint(location: NSEvent.mouseLocation)
+            otherWindow?.rule.flipReferencePoint(location: NSEvent.mouseLocation)
+            return nil
         default:
             return event
         }

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -36,7 +36,7 @@ class VerticalRule: RuleView {
         let mediumTicks: Int
         let smallTicks: Int
         let tinyTicks: Int?
-        
+
         switch prefs.unit {
         case .millimeters:
             tickScale = screen?.dpmm.width ?? NSScreen.defaultDpmm
@@ -123,6 +123,15 @@ class VerticalRule: RuleView {
         self.mouseTickY = mouseY - windowY
     }
 
+    func relativeY(mouseTickY: CGFloat) -> CGFloat {
+        if let refLoc = getReferencePoint() {
+            let windowY = self.window?.frame.origin.y ?? 0
+            let correction = -(refLoc.y - windowY - windowHeight)
+            return mouseTickY - correction
+        }
+        return mouseTickY
+    }
+
     func drawMouseTick(_ mouseTickY: CGFloat) {
         let mouseTick = NSBezierPath()
         let width: CGFloat = 40
@@ -151,7 +160,7 @@ class VerticalRule: RuleView {
             NSAttributedString.Key.foregroundColor: color.mouseNumber,
         ]
 
-        let mouseNumber = self.getMouseNumberLabel(number)
+        let mouseNumber = self.getMouseNumberLabel(relativeY(mouseTickY: number))
         let label = NSAttributedString(string: mouseNumber, attributes: attributes)
         let labelSize = label.size()
 


### PR DESCRIPTION
@pascalpp Hello Pascal

This pull request replaces my previous one of October 2019:
**Feature: crosshair cursor readout relative to a reference point set by the user.**

It works like this:

- user moves the crosshair cursor to the desired reference point and taps on key "." to set it.
- henceforth the x, y readout values are relative to the reference point
- user taps again on key "." to unset it 
- the reference point remains active even if rulers are moved



PS. While I removed my debug printouts from the commit, I left in my debugging tool func printClassAndFunc, which you might find useful for tracking function calls and data during test runs.
You just insert lines like these

       printClassAndFunc()
       printClassAndFunc(info: "mouseTickY=\(mouseTickY) label=\(label)")

If you are not interested, simply remove `DebugUtil.swift` from the project.

Best regards, @rudifa