### PR TITLE
[codex] Add ruler reopen and visibility commands

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		50B146212D03B00000146C0D /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		50B146222D03B00000146C0D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		50B146232D03B00000146C0D /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
-		50B146242D03B00000146C0D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		50B146242D03B00000146C0D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		50B146252D03B00000146C0D /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		50FC527D25BF326800B84228 /* FreeRuler.help */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FreeRuler.help; sourceTree = "<group>"; };
 		53AF6A4225A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/MainMenu.strings; sourceTree = "<group>"; };
@@ -87,8 +87,8 @@
 		6F41028F2260713100F06A10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6F4102902260713100F06A10 /* Free_Ruler.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Free_Ruler.entitlements; sourceTree = "<group>"; };
 		6F41029E22607DC900F06A10 /* HorizontalRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalRule.swift; sourceTree = "<group>"; };
-		6F8CAA3929CC8F7D00C4ED57 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
-		6F8CAA3A29CC8F7D00C4ED57 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/PreferencesController.strings"; sourceTree = "<group>"; };
+		6F8CAA3929CC8F7D00C4ED57 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-hans.lproj/MainMenu.strings"; sourceTree = "<group>"; };
+		6F8CAA3A29CC8F7D00C4ED57 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-hans.lproj/PreferencesController.strings"; sourceTree = "<group>"; };
 		8F629823243003EA004F9099 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		8F629825243003F6004F9099 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/PreferencesController.xib; sourceTree = "<group>"; };
 		8F629828243003FF004F9099 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/PreferencesController.strings; sourceTree = "<group>"; };

--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		50D7BEEB227D432E0008B95E /* RulerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEEA227D432E0008B95E /* RulerWindow.swift */; };
 		50D7BEED227D5C810008B95E /* RuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEEC227D5C810008B95E /* RuleView.swift */; };
 		50FC527E25BF326800B84228 /* FreeRuler.help in Resources */ = {isa = PBXBuildFile; fileRef = 50FC527D25BF326800B84228 /* FreeRuler.help */; };
+		50B146262D03B00000146C0D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 50B146202D03B00000146C0D /* Localizable.strings */; };
 		6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4102882260712F00F06A10 /* AppDelegate.swift */; };
 		6F41028E2260713100F06A10 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41028C2260713100F06A10 /* MainMenu.xib */; };
 		6F41029F22607DC900F06A10 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
@@ -72,6 +73,11 @@
 		50D7BEE8227D43270008B95E /* Ruler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Ruler.swift; sourceTree = "<group>"; };
 		50D7BEEA227D432E0008B95E /* RulerWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulerWindow.swift; sourceTree = "<group>"; };
 		50D7BEEC227D5C810008B95E /* RuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleView.swift; sourceTree = "<group>"; };
+		50B146212D03B00000146C0D /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		50B146222D03B00000146C0D /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		50B146232D03B00000146C0D /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		50B146242D03B00000146C0D /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		50B146252D03B00000146C0D /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		50FC527D25BF326800B84228 /* FreeRuler.help */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FreeRuler.help; sourceTree = "<group>"; };
 		53AF6A4225A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		53AF6A4325A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/PreferencesController.strings; sourceTree = "<group>"; };
@@ -152,6 +158,7 @@
 				50008B6022846FCD001E3EE4 /* Notifications.swift */,
 				6F4102882260712F00F06A10 /* AppDelegate.swift */,
 				6F41028C2260713100F06A10 /* MainMenu.xib */,
+				50B146202D03B00000146C0D /* Localizable.strings */,
 				50D7BEE8227D43270008B95E /* Ruler.swift */,
 				50D7BEE6227D42FD0008B95E /* RulerController.swift */,
 				50D7BEEA227D432E0008B95E /* RulerWindow.swift */,
@@ -266,6 +273,7 @@
 				50C6D891228BDBAD0091F19E /* Images.xcassets in Resources */,
 				50FC527E25BF326800B84228 /* FreeRuler.help in Resources */,
 				507FED44227FFF5300BD77DC /* PreferencesController.xib in Resources */,
+				50B146262D03B00000146C0D /* Localizable.strings in Resources */,
 				6F41028E2260713100F06A10 /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -320,6 +328,18 @@
 				B894A5012BBFE61A005A3B6F /* ja */,
 			);
 			name = PreferencesController.xib;
+			sourceTree = "<group>";
+		};
+		50B146202D03B00000146C0D /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				50B146212D03B00000146C0D /* Base */,
+				50B146222D03B00000146C0D /* de */,
+				50B146232D03B00000146C0D /* fi */,
+				50B146242D03B00000146C0D /* zh-Hans */,
+				50B146252D03B00000146C0D /* ja */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 		6F41028C2260713100F06A10 /* MainMenu.xib */ = {

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -142,6 +142,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func rulerController(orientation: Orientation) -> RulerController? {
         createRulersIfNeeded()
+        return existingRulerController(orientation: orientation)
+    }
+
+    private func existingRulerController(orientation: Orientation) -> RulerController? {
         return rulers.first { $0.ruler.orientation == orientation }
     }
 
@@ -153,6 +157,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func detachRulerWindow(_ window: RulerWindow) {
         for ruler in rulers {
+            guard ruler.rulerWindow != window else { continue }
+
             ruler.rulerWindow.removeChildWindow(window)
             window.removeChildWindow(ruler.rulerWindow)
         }
@@ -302,13 +308,13 @@ extension AppDelegate: NSMenuItemValidation {
         case #selector(closePreferences(_:)):
             return preferencesController?.window?.isKeyWindow == true
         case #selector(toggleHorizontalRuler(_:)):
-            let ruler = rulerController(orientation: .horizontal)
+            let ruler = existingRulerController(orientation: .horizontal)
             menuItem.title = ruler?.rulerWindow.isVisible == true
                 ? NSLocalizedString("Hide Horizontal Ruler", comment: "Menu item title to hide the horizontal ruler")
                 : NSLocalizedString("Show Horizontal Ruler", comment: "Menu item title to show the horizontal ruler")
             return canToggleRulerVisibility
         case #selector(toggleVerticalRuler(_:)):
-            let ruler = rulerController(orientation: .vertical)
+            let ruler = existingRulerController(orientation: .vertical)
             menuItem.title = ruler?.rulerWindow.isVisible == true
                 ? NSLocalizedString("Hide Vertical Ruler", comment: "Menu item title to hide the vertical ruler")
                 : NSLocalizedString("Show Vertical Ruler", comment: "Menu item title to show the vertical ruler")

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -93,7 +93,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         rulerShadowMenuItem?.state = prefs.rulerShadow ? .on : .off
     }
 
-    func showRulers() {
+    func createRulersIfNeeded() {
+        guard rulers.isEmpty else { return }
+
         rulers = [
             RulerController(Ruler(.vertical, name: "vertical-ruler")),
             RulerController(Ruler(.horizontal, name: "horizontal-ruler")),
@@ -103,10 +105,56 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // TODO: provide each ruler with otherRulers: [RulerWindow]
         rulers[0].otherWindow = rulers[1].rulerWindow
         rulers[1].otherWindow = rulers[0].rulerWindow
+    }
+
+    func showRulers() {
+        createRulersIfNeeded()
 
         for ruler in rulers {
-            ruler.showWindow(self)
+            showRuler(ruler)
         }
+    }
+
+    func toggleRuler(orientation: Orientation) {
+        guard canToggleRulerVisibility else { return }
+        guard let ruler = rulerController(orientation: orientation) else { return }
+
+        if ruler.rulerWindow.isVisible {
+            ruler.rulerWindow.orderOut(self)
+        } else {
+            showRuler(ruler)
+        }
+    }
+
+    private func rulerController(orientation: Orientation) -> RulerController? {
+        createRulersIfNeeded()
+        return rulers.first { $0.ruler.orientation == orientation }
+    }
+
+    private func showRuler(_ ruler: RulerController) {
+        ruler.showWindow(self)
+        ruler.rulerWindow.orderFrontRegardless()
+    }
+
+    private var isRulerFrontmost: Bool {
+        return rulers.contains { $0.rulerWindow.isKeyWindow }
+    }
+
+    private var hasVisibleRuler: Bool {
+        return rulers.contains { $0.rulerWindow.isVisible }
+    }
+
+    private var canToggleRulerVisibility: Bool {
+        return isRulerFrontmost || !hasVisibleRuler
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            showRulers()
+            return false
+        }
+
+        return true
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -190,10 +238,48 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         prefs.groupRulers = groupRulers
     }
 
+    @IBAction func showRulers(_ sender: Any) {
+        showRulers()
+    }
+
+    @IBAction func toggleHorizontalRuler(_ sender: Any) {
+        toggleRuler(orientation: .horizontal)
+    }
+
+    @IBAction func toggleVerticalRuler(_ sender: Any) {
+        toggleRuler(orientation: .vertical)
+    }
+
     // MARK: - Application Quit
 
     func applicationWillTerminate(_ aNotification: Notification) {
         prefs.save()
+    }
+
+}
+
+extension AppDelegate: NSMenuItemValidation {
+
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.action {
+        case #selector(toggleHorizontalRuler(_:)):
+            let ruler = rulerController(orientation: .horizontal)
+            menuItem.title = ruler?.rulerWindow.isVisible == true
+                ? NSLocalizedString("Hide Horizontal Ruler", comment: "Menu item title to hide the horizontal ruler")
+                : NSLocalizedString("Show Horizontal Ruler", comment: "Menu item title to show the horizontal ruler")
+            return canToggleRulerVisibility
+        case #selector(toggleVerticalRuler(_:)):
+            let ruler = rulerController(orientation: .vertical)
+            menuItem.title = ruler?.rulerWindow.isVisible == true
+                ? NSLocalizedString("Hide Vertical Ruler", comment: "Menu item title to hide the vertical ruler")
+                : NSLocalizedString("Show Vertical Ruler", comment: "Menu item title to show the vertical ruler")
+            return canToggleRulerVisibility
+        case #selector(showRulers(_:)):
+            menuItem.title = NSLocalizedString("Show All Rulers", comment: "Menu item title to show all ruler windows")
+            return true
+        default:
+            return true
+        }
     }
 
 }

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -119,10 +119,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard canToggleRulerVisibility else { return }
         guard let ruler = rulerController(orientation: orientation) else { return }
 
+        if prefs.groupRulers {
+            prefs.groupRulers = false
+            detachRulerWindows()
+        }
+
         if ruler.rulerWindow.isVisible {
+            detachRulerWindow(ruler.rulerWindow)
             ruler.rulerWindow.orderOut(self)
         } else {
             showRuler(ruler)
+        }
+
+        updateRulerGrouping()
+    }
+
+    private func detachRulerWindows() {
+        for ruler in rulers {
+            detachRulerWindow(ruler.rulerWindow)
         }
     }
 
@@ -134,6 +148,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func showRuler(_ ruler: RulerController) {
         ruler.showWindow(self)
         ruler.rulerWindow.orderFrontRegardless()
+        updateRulerGrouping()
+    }
+
+    private func detachRulerWindow(_ window: RulerWindow) {
+        for ruler in rulers {
+            ruler.rulerWindow.removeChildWindow(window)
+            window.removeChildWindow(ruler.rulerWindow)
+        }
+    }
+
+    private func updateRulerGrouping() {
+        for ruler in rulers {
+            ruler.updateChildWindow()
+        }
     }
 
     private var isRulerFrontmost: Bool {
@@ -218,6 +246,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    @IBAction func closePreferences(_ sender: Any) {
+        guard preferencesController?.window?.isKeyWindow == true else { return }
+        preferencesController?.close()
+    }
+
     @IBAction func alignRulersAtMouseLocation(_ sender: Any) {
         var mouseLoc = NSEvent.mouseLocation
         mouseLoc.x = mouseLoc.x.rounded()
@@ -228,14 +261,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @IBAction func resetRulerPositions(_ sender: Any) {
+        createRulersIfNeeded()
+
         // ungroup rulers during reset operation
         let groupRulers = prefs.groupRulers
         prefs.groupRulers = false
         for ruler in rulers {
             ruler.resetPosition()
+            showRuler(ruler)
         }
         // reset groupRulers to previous value
         prefs.groupRulers = groupRulers
+        updateRulerGrouping()
     }
 
     @IBAction func showRulers(_ sender: Any) {
@@ -262,6 +299,8 @@ extension AppDelegate: NSMenuItemValidation {
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
+        case #selector(closePreferences(_:)):
+            return preferencesController?.window?.isKeyWindow == true
         case #selector(toggleHorizontalRuler(_:)):
             let ruler = rulerController(orientation: .horizontal)
             menuItem.title = ruler?.rulerWindow.isVisible == true

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -127,11 +127,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if ruler.rulerWindow.isVisible {
             detachRulerWindow(ruler.rulerWindow)
             ruler.rulerWindow.orderOut(self)
+            updateRulerGrouping()
         } else {
             showRuler(ruler)
         }
-
-        updateRulerGrouping()
     }
 
     private func detachRulerWindows() {

--- a/Free Ruler/Base.lproj/Localizable.strings
+++ b/Free Ruler/Base.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"Horizontal Ruler" = "Horizontal Ruler";
+"Vertical Ruler" = "Vertical Ruler";
+"Hide Horizontal Ruler" = "Hide Horizontal Ruler";
+"Show Horizontal Ruler" = "Show Horizontal Ruler";
+"Hide Vertical Ruler" = "Hide Vertical Ruler";
+"Show Vertical Ruler" = "Show Vertical Ruler";
+"Show All Rulers" = "Show All Rulers";

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -224,6 +224,11 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
                         <items>
+                            <menuItem title="Close" keyEquivalent="w" id="n0M-rw-v5l">
+                                <connections>
+                                    <action selector="closePreferences:" target="Voe-Tx-rLC" id="X4C-ak-CJh"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
                                 <connections>
                                     <action selector="performMiniaturize:" target="-1" id="VwT-WD-YPe"/>

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -79,9 +79,23 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Ruler" id="bib-Uj-vzu">
                         <items>
-                            <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                            <menuItem title="Hide Horizontal Ruler" keyEquivalent="h" id="fLB-gk-0Jy">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
-                                    <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
+                                    <action selector="toggleHorizontalRuler:" target="Voe-Tx-rLC" id="vy9-mG-eOp"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Hide Vertical Ruler" keyEquivalent="v" id="NgD-7h-fjO">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="toggleVerticalRuler:" target="Voe-Tx-rLC" id="vGH-ND-x37"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="mwO-GY-nrW"/>
+                            <menuItem title="Show All Rulers" id="qVa-aF-DQ8">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showRulers:" target="Voe-Tx-rLC" id="NLA-hk-Wbc"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Free Ruler/PreferencesController.swift
+++ b/Free Ruler/PreferencesController.swift
@@ -21,6 +21,7 @@ class PreferencesController: NSWindowController, NSWindowDelegate, NotificationP
     override func windowDidLoad() {
         super.windowDidLoad()
 
+        window?.delegate = self
         window?.isMovableByWindowBackground = true
 
         subscribeToPrefs()

--- a/Free Ruler/RulerWindow.swift
+++ b/Free Ruler/RulerWindow.swift
@@ -27,6 +27,7 @@ class RulerWindow: NSPanel {
         )
 
         self.alphaValue = windowAlphaValue(prefs.foregroundOpacity)
+        self.title = getTitle(for: ruler.orientation)
         self.minSize = getMinSize(ruler: ruler)
         self.maxSize = getMaxSize(ruler: ruler)
 
@@ -52,6 +53,21 @@ class RulerWindow: NSPanel {
         set {}
     }
 
+}
+
+private func getTitle(for orientation: Orientation) -> String {
+    switch orientation {
+    case .horizontal:
+        return NSLocalizedString(
+            "Horizontal Ruler",
+            comment: "Window title for the horizontal ruler"
+        )
+    case .vertical:
+        return NSLocalizedString(
+            "Vertical Ruler",
+            comment: "Window title for the vertical ruler"
+        )
+    }
 }
 
 extension RulerWindow {

--- a/Free Ruler/de.lproj/Localizable.strings
+++ b/Free Ruler/de.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"Horizontal Ruler" = "Horizontales Lineal";
+"Vertical Ruler" = "Vertikales Lineal";
+"Hide Horizontal Ruler" = "Horizontales Lineal ausblenden";
+"Show Horizontal Ruler" = "Horizontales Lineal anzeigen";
+"Hide Vertical Ruler" = "Vertikales Lineal ausblenden";
+"Show Vertical Ruler" = "Vertikales Lineal anzeigen";
+"Show All Rulers" = "Alle Lineale anzeigen";

--- a/Free Ruler/de.lproj/MainMenu.strings
+++ b/Free Ruler/de.lproj/MainMenu.strings
@@ -59,6 +59,9 @@
 /* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
 "OY7-WF-poV.title" = "Im Dock ablegen";
 
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "n0M-rw-v5l"; */
+"n0M-rw-v5l.title" = "Schließen";
+
 /* Class = "NSMenuItem"; title = "Hide Free Ruler"; ObjectID = "Olw-nP-bQN"; */
 "Olw-nP-bQN.title" = "Free Ruler ausblenden";
 

--- a/Free Ruler/fi.lproj/Localizable.strings
+++ b/Free Ruler/fi.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"Horizontal Ruler" = "Vaakaviivain";
+"Vertical Ruler" = "Pystyviivain";
+"Hide Horizontal Ruler" = "Kätke vaakaviivain";
+"Show Horizontal Ruler" = "Näytä vaakaviivain";
+"Hide Vertical Ruler" = "Kätke pystyviivain";
+"Show Vertical Ruler" = "Näytä pystyviivain";
+"Show All Rulers" = "Näytä kaikki viivaimet";

--- a/Free Ruler/fi.lproj/MainMenu.strings
+++ b/Free Ruler/fi.lproj/MainMenu.strings
@@ -59,6 +59,9 @@
 /* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
 "OY7-WF-poV.title" = "Pienennä";
 
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "n0M-rw-v5l"; */
+"n0M-rw-v5l.title" = "Sulje";
+
 /* Class = "NSMenuItem"; title = "Hide Free Ruler"; ObjectID = "Olw-nP-bQN"; */
 "Olw-nP-bQN.title" = "Kätke Free Ruler";
 

--- a/Free Ruler/ja.lproj/Localizable.strings
+++ b/Free Ruler/ja.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"Horizontal Ruler" = "水平定規";
+"Vertical Ruler" = "垂直定規";
+"Hide Horizontal Ruler" = "水平定規を非表示";
+"Show Horizontal Ruler" = "水平定規を表示";
+"Hide Vertical Ruler" = "垂直定規を非表示";
+"Show Vertical Ruler" = "垂直定規を表示";
+"Show All Rulers" = "すべての定規を表示";

--- a/Free Ruler/ja.lproj/MainMenu.strings
+++ b/Free Ruler/ja.lproj/MainMenu.strings
@@ -62,6 +62,9 @@
 /* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
 "OY7-WF-poV.title" = "しまう";
 
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "n0M-rw-v5l"; */
+"n0M-rw-v5l.title" = "閉じる";
+
 /* Class = "NSMenuItem"; title = "Hide Free Ruler"; ObjectID = "Olw-nP-bQN"; */
 "Olw-nP-bQN.title" = "Free Rulerを非表示";
 

--- a/Free Ruler/zh-hans.lproj/Localizable.strings
+++ b/Free Ruler/zh-hans.lproj/Localizable.strings
@@ -1,0 +1,7 @@
+"Horizontal Ruler" = "水平标尺";
+"Vertical Ruler" = "垂直标尺";
+"Hide Horizontal Ruler" = "隐藏水平标尺";
+"Show Horizontal Ruler" = "显示水平标尺";
+"Hide Vertical Ruler" = "隐藏垂直标尺";
+"Show Vertical Ruler" = "显示垂直标尺";
+"Show All Rulers" = "显示所有标尺";

--- a/Free Ruler/zh-hans.lproj/MainMenu.strings
+++ b/Free Ruler/zh-hans.lproj/MainMenu.strings
@@ -59,6 +59,9 @@
 /* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
 "OY7-WF-poV.title" = "最小化";
 
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "n0M-rw-v5l"; */
+"n0M-rw-v5l.title" = "关闭";
+
 /* Class = "NSMenuItem"; title = "Hide Free Ruler"; ObjectID = "Olw-nP-bQN"; */
 "Olw-nP-bQN.title" = "隐藏 Free Ruler";
 


### PR DESCRIPTION
Fixes #146 

## Summary
- Add Ruler menu commands to hide/show the horizontal and vertical rulers and show all rulers again.
- Give ruler windows localized titles so they appear meaningfully in macOS window UI.
- Reopen/show rulers when the app is reopened with no visible windows.
- Make Reset Ruler Positions restore both rulers onscreen.
- Add a preferences-only Window > Close command so Command-W closes Preferences without affecting ruler panels.

## Why
This addresses App Store review feedback in #146: users need a menu path to reopen the ruler UI after the main app windows have been hidden or closed.

## Validation
- `xcodebuild test -project '/Users/pascal/Projects/personal/FreeRuler/Free Ruler.xcodeproj' -scheme 'Free Ruler' -configuration Debug -derivedDataPath '/Users/pascal/Documents/Codex/2026-06-05/i-have-an-app-pascalpp-freeruler/work/DerivedData-FreeRuler-146' CODE_SIGNING_ALLOWED=NO`
- All 4 `RulerCoreTests` passed.