### PR TITLE
[codex] Add ruler UI tests

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		50A137012D03A00000137C0D /* RulerCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A137002D03A00000137C0D /* RulerCoreTests.swift */; };
 		50A137032D03A00000137C0D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A137022D03A00000137C0D /* XCTest.framework */; };
+		50A147012D03C00000147C0D /* FreeRulerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A147002D03C00000147C0D /* FreeRulerUITests.swift */; };
+		50A147032D03C00000147C0D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A137022D03A00000137C0D /* XCTest.framework */; };
 		50008B6122846FCD001E3EE4 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50008B6022846FCD001E3EE4 /* Notifications.swift */; };
 		5012CAAD226AB09000BD9565 /* VerticalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5012CAAC226AB09000BD9565 /* VerticalRule.swift */; };
 		507FED43227FFF5300BD77DC /* PreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507FED41227FFF5300BD77DC /* PreferencesController.swift */; };
@@ -29,6 +31,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		50A137102D03A00000137C0D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6F41027D2260712F00F06A10 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F4102842260712F00F06A10;
+			remoteInfo = "Free Ruler";
+		};
+		50A1470C2D03C00000147C0D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6F41027D2260712F00F06A10 /* Project object */;
 			proxyType = 1;
@@ -63,6 +72,8 @@
 		50A137002D03A00000137C0D /* RulerCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulerCoreTests.swift; sourceTree = "<group>"; };
 		50A137022D03A00000137C0D /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = System/Library/Frameworks/XCTest.framework; sourceTree = SDKROOT; };
 		50A137042D03A00000137C0D /* FreeRulerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FreeRulerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		50A147002D03C00000147C0D /* FreeRulerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeRulerUITests.swift; sourceTree = "<group>"; };
+		50A147022D03C00000147C0D /* FreeRulerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FreeRulerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		50008B6022846FCD001E3EE4 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		5012CAAC226AB09000BD9565 /* VerticalRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalRule.swift; sourceTree = "<group>"; };
 		507FED41227FFF5300BD77DC /* PreferencesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesController.swift; sourceTree = "<group>"; };
@@ -105,6 +116,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		50A147042D03C00000147C0D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50A147032D03C00000147C0D /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6F4102822260712F00F06A10 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -120,6 +139,7 @@
 			children = (
 				6F4102872260712F00F06A10 /* Free Ruler */,
 				50A137062D03A00000137C0D /* FreeRulerTests */,
+				50A147072D03C00000147C0D /* FreeRulerUITests */,
 				50A137072D03A00000137C0D /* Frameworks */,
 				6F4102862260712F00F06A10 /* Products */,
 			);
@@ -130,6 +150,7 @@
 			children = (
 				6F4102852260712F00F06A10 /* Free Ruler.app */,
 				50A137042D03A00000137C0D /* FreeRulerTests.xctest */,
+				50A147022D03C00000147C0D /* FreeRulerUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -140,6 +161,14 @@
 				50A137002D03A00000137C0D /* RulerCoreTests.swift */,
 			);
 			path = FreeRulerTests;
+			sourceTree = "<group>";
+		};
+		50A147072D03C00000147C0D /* FreeRulerUITests */ = {
+			isa = PBXGroup;
+			children = (
+				50A147002D03C00000147C0D /* FreeRulerUITests.swift */,
+			);
+			path = FreeRulerUITests;
 			sourceTree = "<group>";
 		};
 		50A137072D03A00000137C0D /* Frameworks */ = {
@@ -196,6 +225,24 @@
 			productReference = 50A137042D03A00000137C0D /* FreeRulerTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		50A147082D03C00000147C0D /* FreeRulerUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 50A1470B2D03C00000147C0D /* Build configuration list for PBXNativeTarget "FreeRulerUITests" */;
+			buildPhases = (
+				50A147052D03C00000147C0D /* Sources */,
+				50A147042D03C00000147C0D /* Frameworks */,
+				50A147062D03C00000147C0D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				50A1470D2D03C00000147C0D /* PBXTargetDependency */,
+			);
+			name = FreeRulerUITests;
+			productName = FreeRulerUITests;
+			productReference = 50A147022D03C00000147C0D /* FreeRulerUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		6F4102842260712F00F06A10 /* Free Ruler */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6F4102932260713100F06A10 /* Build configuration list for PBXNativeTarget "Free Ruler" */;
@@ -230,6 +277,10 @@
 						CreatedOnToolsVersion = 26.3;
 						TestTargetID = 6F4102842260712F00F06A10;
 					};
+					50A147082D03C00000147C0D = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 6F4102842260712F00F06A10;
+					};
 					6F4102842260712F00F06A10 = {
 						CreatedOnToolsVersion = 10.2;
 					};
@@ -254,12 +305,20 @@
 			targets = (
 				6F4102842260712F00F06A10 /* Free Ruler */,
 				50A137082D03A00000137C0D /* FreeRulerTests */,
+				50A147082D03C00000147C0D /* FreeRulerUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		50A1370A2D03A00000137C0D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		50A147062D03C00000147C0D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -289,6 +348,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		50A147052D03C00000147C0D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50A147012D03C00000147C0D /* FreeRulerUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6F4102812260712F00F06A10 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -314,6 +381,11 @@
 			isa = PBXTargetDependency;
 			target = 6F4102842260712F00F06A10 /* Free Ruler */;
 			targetProxy = 50A137102D03A00000137C0D /* PBXContainerItemProxy */;
+		};
+		50A1470D2D03C00000147C0D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6F4102842260712F00F06A10 /* Free Ruler */;
+			targetProxy = 50A1470C2D03C00000147C0D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -386,6 +458,36 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Free Ruler.app/Contents/MacOS/Free Ruler";
+			};
+			name = Release;
+		};
+		50A147092D03C00000147C0D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = FreeRulerUITests;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pascal.freeruler.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "Free Ruler";
+			};
+			name = Debug;
+		};
+		50A1470A2D03C00000147C0D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = FreeRulerUITests;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pascal.freeruler.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = "Free Ruler";
 			};
 			name = Release;
 		};
@@ -574,6 +676,15 @@
 			buildConfigurations = (
 				50A1370B2D03A00000137C0D /* Debug */,
 				50A1370C2D03A00000137C0D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		50A1470B2D03C00000147C0D /* Build configuration list for PBXNativeTarget "FreeRulerUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				50A147092D03C00000147C0D /* Debug */,
+				50A1470A2D03C00000147C0D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Free Ruler.xcodeproj/xcshareddata/xcschemes/Free Ruler.xcscheme
+++ b/Free Ruler.xcodeproj/xcshareddata/xcschemes/Free Ruler.xcscheme
@@ -34,6 +34,20 @@
                ReferencedContainer = "container:Free Ruler.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "50A147082D03C00000147C0D"
+               BuildableName = "FreeRulerUITests.xctest"
+               BlueprintName = "FreeRulerUITests"
+               ReferencedContainer = "container:Free Ruler.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -59,6 +73,17 @@
                BlueprintIdentifier = "50A137082D03A00000137C0D"
                BuildableName = "FreeRulerTests.xctest"
                BlueprintName = "FreeRulerTests"
+               ReferencedContainer = "container:Free Ruler.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "50A147082D03C00000147C0D"
+               BuildableName = "FreeRulerUITests.xctest"
+               BlueprintName = "FreeRulerUITests"
                ReferencedContainer = "container:Free Ruler.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -2,6 +2,7 @@ import Cocoa
 
 let env = ProcessInfo.processInfo.environment
 let APP_ICON_HELPER = env["APP_ICON_HELPER"] != nil
+let UI_TESTS = env["FREE_RULER_UI_TESTS"] != nil
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -31,6 +32,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Lifecycle
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+
+        if UI_TESTS {
+            resetStateForUITests()
+        }
 
         subscribeToPrefs()
         updateDisplay()
@@ -91,6 +96,28 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func updateRulerShadowMenuItem() {
         rulerShadowMenuItem?.state = prefs.rulerShadow ? .on : .off
+    }
+
+    private func resetStateForUITests() {
+        let defaults = UserDefaults.standard
+        [
+            "groupRulers",
+            "floatRulers",
+            "rulerShadow",
+            "foregroundOpacity",
+            "backgroundOpacity",
+            "unit",
+            "NSWindow Frame horizontal-ruler",
+            "NSWindow Frame vertical-ruler",
+            "NSWindow Frame preferencesWindow",
+        ].forEach(defaults.removeObject(forKey:))
+
+        prefs.groupRulers = true
+        prefs.floatRulers = true
+        prefs.rulerShadow = false
+        prefs.foregroundOpacity = 90
+        prefs.backgroundOpacity = 50
+        prefs.unit = .pixels
     }
 
     func createRulersIfNeeded() {

--- a/Free Ruler/PreferencesController.swift
+++ b/Free Ruler/PreferencesController.swift
@@ -24,8 +24,12 @@ class PreferencesController: NSWindowController, NSWindowDelegate, NotificationP
         window?.delegate = self
         window?.identifier = NSUserInterfaceItemIdentifier("preferences-window")
         window?.isMovableByWindowBackground = true
+        floatRulersCheckbox.identifier = NSUserInterfaceItemIdentifier("float-rulers-checkbox")
+        floatRulersCheckbox.setAccessibilityIdentifier("float-rulers-checkbox")
         groupRulersCheckbox.identifier = NSUserInterfaceItemIdentifier("group-rulers-checkbox")
         groupRulersCheckbox.setAccessibilityIdentifier("group-rulers-checkbox")
+        rulerShadowCheckbox.identifier = NSUserInterfaceItemIdentifier("ruler-shadow-checkbox")
+        rulerShadowCheckbox.setAccessibilityIdentifier("ruler-shadow-checkbox")
 
         subscribeToPrefs()
         updateView()

--- a/Free Ruler/PreferencesController.swift
+++ b/Free Ruler/PreferencesController.swift
@@ -22,7 +22,10 @@ class PreferencesController: NSWindowController, NSWindowDelegate, NotificationP
         super.windowDidLoad()
 
         window?.delegate = self
+        window?.identifier = NSUserInterfaceItemIdentifier("preferences-window")
         window?.isMovableByWindowBackground = true
+        groupRulersCheckbox.identifier = NSUserInterfaceItemIdentifier("group-rulers-checkbox")
+        groupRulersCheckbox.setAccessibilityIdentifier("group-rulers-checkbox")
 
         subscribeToPrefs()
         updateView()

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -75,6 +75,10 @@ class RuleView: NSView {
         }
     }
 
+    override func accessibilityValue() -> Any? {
+        return getUnitLabel()
+    }
+
     func getMouseNumberLabel(_ number: CGFloat) -> String {
         switch prefs.unit {
         case .pixels:

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -249,7 +249,7 @@ extension RulerController {
         // print(ruler.orientation, "onKeyDown")
 
         let shift = event.modifierFlags.contains(.shift)
-        let commandModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let keyboardModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
         switch Int(event.keyCode) {
         case kVK_LeftArrow:
@@ -264,7 +264,7 @@ extension RulerController {
         case kVK_DownArrow:
             rulerWindow.nudgeDown(withShift: shift)
             return nil
-        case kVK_ANSI_G where commandModifiers.isEmpty:
+        case kVK_ANSI_G where keyboardModifiers.isEmpty:
             prefs.groupRulers = !prefs.groupRulers
             return nil
         default:

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -249,6 +249,7 @@ extension RulerController {
         // print(ruler.orientation, "onKeyDown")
 
         let shift = event.modifierFlags.contains(.shift)
+        let commandModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
         switch Int(event.keyCode) {
         case kVK_LeftArrow:
@@ -262,6 +263,9 @@ extension RulerController {
             return nil
         case kVK_DownArrow:
             rulerWindow.nudgeDown(withShift: shift)
+            return nil
+        case kVK_ANSI_G where commandModifiers.isEmpty:
+            prefs.groupRulers = !prefs.groupRulers
             return nil
         default:
             return event

--- a/Free Ruler/RulerWindow.swift
+++ b/Free Ruler/RulerWindow.swift
@@ -28,6 +28,8 @@ class RulerWindow: NSPanel {
 
         self.alphaValue = windowAlphaValue(prefs.foregroundOpacity)
         self.title = getTitle(for: ruler.orientation)
+        self.identifier = NSUserInterfaceItemIdentifier(getIdentifier(for: ruler.orientation))
+        self.setAccessibilityIdentifier(getIdentifier(for: ruler.orientation))
         self.minSize = getMinSize(ruler: ruler)
         self.maxSize = getMaxSize(ruler: ruler)
 
@@ -39,6 +41,8 @@ class RulerWindow: NSPanel {
         rule.wantsLayer = true
         rule.layer?.borderColor = CGColor(gray: 0, alpha: 0.5)
         rule.layer?.borderWidth = 1.0
+        rule.setAccessibilityElement(true)
+        rule.setAccessibilityIdentifier(getIdentifier(for: ruler.orientation))
 
         rule.nextResponder = self
         self.contentView = rule
@@ -67,6 +71,15 @@ private func getTitle(for orientation: Orientation) -> String {
             "Vertical Ruler",
             comment: "Window title for the vertical ruler"
         )
+    }
+}
+
+private func getIdentifier(for orientation: Orientation) -> String {
+    switch orientation {
+    case .horizontal:
+        return "horizontal-ruler-window"
+    case .vertical:
+        return "vertical-ruler-window"
     }
 }
 

--- a/Free Ruler/RulerWindow.swift
+++ b/Free Ruler/RulerWindow.swift
@@ -42,7 +42,7 @@ class RulerWindow: NSPanel {
         rule.layer?.borderColor = CGColor(gray: 0, alpha: 0.5)
         rule.layer?.borderWidth = 1.0
         rule.setAccessibilityElement(true)
-        rule.setAccessibilityIdentifier(getIdentifier(for: ruler.orientation))
+        rule.setAccessibilityIdentifier(getRuleIdentifier(for: ruler.orientation))
 
         rule.nextResponder = self
         self.contentView = rule
@@ -80,6 +80,15 @@ private func getIdentifier(for orientation: Orientation) -> String {
         return "horizontal-ruler-window"
     case .vertical:
         return "vertical-ruler-window"
+    }
+}
+
+private func getRuleIdentifier(for orientation: Orientation) -> String {
+    switch orientation {
+    case .horizontal:
+        return "horizontal-ruler-view"
+    case .vertical:
+        return "vertical-ruler-view"
     }
 }
 

--- a/FreeRulerUITests/FreeRulerUITests.swift
+++ b/FreeRulerUITests/FreeRulerUITests.swift
@@ -113,6 +113,59 @@ final class FreeRulerUITests: XCTestCase {
         XCTAssertTrue(verticalRuler.waitForExistence(timeout: 2))
     }
 
+    func testFloatShadowAndUnitKeyboardCommands() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
+
+        horizontalRuler.click()
+        XCTAssertTrue(floatRulersEnabledInPreferences())
+
+        horizontalRuler.click()
+        app.typeKey("f", modifierFlags: [])
+        XCTAssertFalse(floatRulersEnabledInPreferences())
+
+        horizontalRuler.click()
+        app.typeKey("f", modifierFlags: [])
+        XCTAssertTrue(floatRulersEnabledInPreferences())
+
+        horizontalRuler.click()
+        XCTAssertFalse(rulerShadowEnabledInPreferences())
+
+        horizontalRuler.click()
+        app.typeKey("s", modifierFlags: [])
+        XCTAssertTrue(rulerShadowEnabledInPreferences())
+
+        horizontalRuler.click()
+        app.typeKey("s", modifierFlags: [])
+        XCTAssertFalse(rulerShadowEnabledInPreferences())
+
+        horizontalRuler.click()
+        XCTAssertEqual(horizontalRulerView.value as? String, "px")
+
+        app.typeKey("u", modifierFlags: [])
+        XCTAssertEqual(horizontalRulerView.value as? String, "mm")
+
+        app.typeKey("u", modifierFlags: [])
+        XCTAssertEqual(horizontalRulerView.value as? String, "in")
+
+        app.typeKey("u", modifierFlags: [])
+        XCTAssertEqual(horizontalRulerView.value as? String, "px")
+    }
+
+    func testAlignRulersAtMouseLocationKeyboardCommand() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
+
+        let originalHorizontalFrame = horizontalRuler.frame
+        let originalVerticalFrame = verticalRuler.frame
+
+        verticalRuler.click()
+        app.typeKey("o", modifierFlags: [])
+
+        XCTAssertTrue(horizontalRuler.waitForFrameChange(from: originalHorizontalFrame, timeout: 2))
+        XCTAssertTrue(verticalRuler.waitForFrameChange(from: originalVerticalFrame, timeout: 2))
+    }
+
     private var horizontalRuler: XCUIElement {
         app.dialogs["horizontal-ruler-window"]
     }
@@ -121,12 +174,24 @@ final class FreeRulerUITests: XCTestCase {
         app.dialogs["vertical-ruler-window"]
     }
 
+    private var horizontalRulerView: XCUIElement {
+        app.otherElements["horizontal-ruler-view"]
+    }
+
     private var preferencesWindow: XCUIElement {
         app.windows["Free Ruler Preferences"]
     }
 
+    private var floatRulersCheckbox: XCUIElement {
+        app.checkBoxes["float-rulers-checkbox"]
+    }
+
     private var groupRulersCheckbox: XCUIElement {
         app.checkBoxes["group-rulers-checkbox"]
+    }
+
+    private var rulerShadowCheckbox: XCUIElement {
+        app.checkBoxes["ruler-shadow-checkbox"]
     }
 
     private func openPreferences() {
@@ -160,6 +225,20 @@ final class FreeRulerUITests: XCTestCase {
         closePreferences()
         return enabled
     }
+
+    private func floatRulersEnabledInPreferences() -> Bool {
+        openPreferences()
+        let enabled = floatRulersCheckbox.isChecked
+        closePreferences()
+        return enabled
+    }
+
+    private func rulerShadowEnabledInPreferences() -> Bool {
+        openPreferences()
+        let enabled = rulerShadowCheckbox.isChecked
+        closePreferences()
+        return enabled
+    }
 }
 
 private extension XCUIElement {
@@ -167,6 +246,20 @@ private extension XCUIElement {
         let predicate = NSPredicate(format: "exists == false")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    func waitForFrameChange(from originalFrame: CGRect, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if !frame.equalTo(originalFrame) {
+                return true
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        return !frame.equalTo(originalFrame)
     }
 
     var isChecked: Bool {

--- a/FreeRulerUITests/FreeRulerUITests.swift
+++ b/FreeRulerUITests/FreeRulerUITests.swift
@@ -1,0 +1,177 @@
+import XCTest
+
+final class FreeRulerUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        app = XCUIApplication()
+        app.launchEnvironment["FREE_RULER_UI_TESTS"] = "1"
+        app.launch()
+        app.activate()
+    }
+
+    override func tearDownWithError() throws {
+        app.terminate()
+        app = nil
+    }
+
+    func testRulerVisibilityKeyboardCommands() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
+
+        horizontalRuler.click()
+        app.typeKey("h", modifierFlags: [])
+        XCTAssertTrue(horizontalRuler.waitForNonExistence(timeout: 2))
+        XCTAssertTrue(verticalRuler.exists)
+
+        app.typeKey("h", modifierFlags: [])
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 2))
+
+        verticalRuler.click()
+        app.typeKey("v", modifierFlags: [])
+        XCTAssertTrue(verticalRuler.waitForNonExistence(timeout: 2))
+        XCTAssertTrue(horizontalRuler.exists)
+
+        app.typeKey("v", modifierFlags: [])
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 2))
+    }
+
+    func testGroupedRulerToggleUngroupsAndHidesRequestedRuler() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
+
+        horizontalRuler.click()
+        setGroupRulers(true)
+        XCTAssertTrue(groupRulersEnabledInPreferences())
+
+        horizontalRuler.click()
+        app.typeKey("v", modifierFlags: [])
+
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 2))
+        XCTAssertTrue(verticalRuler.waitForNonExistence(timeout: 2))
+        XCTAssertFalse(groupRulersEnabledInPreferences())
+    }
+
+    func testGroupRulersKeyboardCommandUngroupsOnFirstAttempt() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
+
+        horizontalRuler.click()
+        setGroupRulers(true)
+        XCTAssertTrue(groupRulersEnabledInPreferences())
+
+        horizontalRuler.click()
+        app.typeKey("g", modifierFlags: [])
+
+        XCTAssertFalse(groupRulersEnabledInPreferences())
+
+        setGroupRulers(true)
+        XCTAssertTrue(groupRulersEnabledInPreferences())
+
+        verticalRuler.click()
+        app.typeKey("g", modifierFlags: [])
+
+        XCTAssertFalse(groupRulersEnabledInPreferences())
+    }
+
+    func testPreferencesCloseWithCommandW() {
+        app.typeKey(",", modifierFlags: .command)
+
+        let preferences = app.windows["Free Ruler Preferences"]
+        XCTAssertTrue(preferences.waitForExistence(timeout: 3))
+
+        app.typeKey("w", modifierFlags: .command)
+        XCTAssertTrue(preferences.waitForNonExistence(timeout: 2))
+    }
+
+    func testHiddenRulersCanBeRestoredAndResetRestoresVisibility() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
+
+        horizontalRuler.click()
+        app.typeKey("h", modifierFlags: [])
+        XCTAssertTrue(horizontalRuler.waitForNonExistence(timeout: 2))
+
+        verticalRuler.click()
+        app.typeKey("v", modifierFlags: [])
+        XCTAssertTrue(verticalRuler.waitForNonExistence(timeout: 2))
+
+        app.typeKey("h", modifierFlags: [])
+        app.typeKey("v", modifierFlags: [])
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 2))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 2))
+
+        horizontalRuler.click()
+        app.typeKey("h", modifierFlags: [])
+        XCTAssertTrue(horizontalRuler.waitForNonExistence(timeout: 2))
+
+        app.typeKey("r", modifierFlags: .command)
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 2))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 2))
+    }
+
+    private var horizontalRuler: XCUIElement {
+        app.dialogs["horizontal-ruler-window"]
+    }
+
+    private var verticalRuler: XCUIElement {
+        app.dialogs["vertical-ruler-window"]
+    }
+
+    private var preferencesWindow: XCUIElement {
+        app.windows["Free Ruler Preferences"]
+    }
+
+    private var groupRulersCheckbox: XCUIElement {
+        app.checkBoxes["group-rulers-checkbox"]
+    }
+
+    private func openPreferences() {
+        if !preferencesWindow.exists {
+            app.typeKey(",", modifierFlags: .command)
+            XCTAssertTrue(preferencesWindow.waitForExistence(timeout: 3))
+        }
+    }
+
+    private func closePreferences() {
+        if preferencesWindow.exists {
+            preferencesWindow.click()
+            app.typeKey("w", modifierFlags: .command)
+            XCTAssertTrue(preferencesWindow.waitForNonExistence(timeout: 2))
+        }
+    }
+
+    private func setGroupRulers(_ enabled: Bool) {
+        openPreferences()
+
+        if groupRulersCheckbox.isChecked != enabled {
+            groupRulersCheckbox.click()
+        }
+
+        closePreferences()
+    }
+
+    private func groupRulersEnabledInPreferences() -> Bool {
+        openPreferences()
+        let enabled = groupRulersCheckbox.isChecked
+        closePreferences()
+        return enabled
+    }
+}
+
+private extension XCUIElement {
+    var isChecked: Bool {
+        if let value = value as? String {
+            return value == "1"
+        }
+
+        if let value = value as? NSNumber {
+            return value.boolValue
+        }
+
+        return false
+    }
+}

--- a/FreeRulerUITests/FreeRulerUITests.swift
+++ b/FreeRulerUITests/FreeRulerUITests.swift
@@ -163,6 +163,12 @@ final class FreeRulerUITests: XCTestCase {
 }
 
 private extension XCUIElement {
+    func waitForNonExistence(timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
     var isChecked: Bool {
         if let value = value as? String {
             return value == "1"


### PR DESCRIPTION
## Summary

- Add a `FreeRulerUITests` UI test target and include it in the shared Xcode scheme.
- Cover ruler visibility shortcuts, grouped ruler behavior, first-press `G` ungrouping, Preferences `⌘W`, and reset/restoration behavior.
- Add stable accessibility identifiers and a UI-test launch reset path so the tests start from known preferences.
- Route unmodified `G` through the ruler key monitor so grouping toggles reliably when a ruler panel is focused.

Fixes #147.

## Validation

```sh
xcodebuild test -project '/Users/pascal/Projects/personal/FreeRuler/Free Ruler.xcodeproj' -scheme 'Free Ruler' -configuration Debug -derivedDataPath '/private/tmp/FreeRulerDerivedData147-all2'
```

Result: `** TEST SUCCEEDED **` with 5 UI tests passing and the existing `RulerCoreTests` passing.