### PR TITLE
[codex] Manage NotificationCenter observers via tokens

### DIFF
--- a/Free Ruler/Notifications.swift
+++ b/Free Ruler/Notifications.swift
@@ -20,15 +20,16 @@ extension NotificationPoster {
 protocol NotificationObserver {}
 extension NotificationObserver {
 
-    func addObserver(_ forName: Notification.Name, using: @escaping (Notification) -> Void) {
+    func addObserver(_ forName: Notification.Name, using: @escaping (Notification) -> Void) -> NSObjectProtocol {
         NotificationCenter.default.addObserver(forName: forName, object: nil, queue: nil, using: using)
     }
 
-    // call removeObserver in your class deinit
-    // deinit {
-    //    removeObserver()
-    // }
-    func removeObserver() {
-        NotificationCenter.default.removeObserver(self)
+    func removeObserver(_ observer: NSObjectProtocol) {
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    func removeObservers(_ observers: inout [NSObjectProtocol]) {
+        observers.forEach(removeObserver)
+        observers.removeAll()
     }
 }

--- a/Free Ruler/Notifications.swift
+++ b/Free Ruler/Notifications.swift
@@ -21,7 +21,7 @@ protocol NotificationObserver {}
 extension NotificationObserver {
 
     func addObserver(_ forName: Notification.Name, using: @escaping (Notification) -> Void) -> NSObjectProtocol {
-        NotificationCenter.default.addObserver(forName: forName, object: nil, queue: nil, using: using)
+        return NotificationCenter.default.addObserver(forName: forName, object: nil, queue: nil, using: using)
     }
 
     func removeObserver(_ observer: NSObjectProtocol) {

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -5,6 +5,7 @@ import Carbon.HIToolbox // For key constants
 class RulerController: NSWindowController, NSWindowDelegate, NotificationObserver {
 
     var observers: [NSKeyValueObservation] = []
+    var notificationObservers: [NSObjectProtocol] = []
 
     let ruler: Ruler
 
@@ -60,12 +61,18 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     deinit {
-        removeObserver()
+        removeObservers(&notificationObservers)
     }
 
     func createObservers() {
-        addObserver(.preferencesWindowOpened) { _ in self.preferencesWindowOpen = true }
-        addObserver(.preferencesWindowClosed) { _ in self.preferencesWindowOpen = false }
+        notificationObservers = [
+            addObserver(.preferencesWindowOpened) { [weak self] _ in
+                self?.preferencesWindowOpen = true
+            },
+            addObserver(.preferencesWindowClosed) { [weak self] _ in
+                self?.preferencesWindowOpen = false
+            },
+        ]
     }
 
     func windowWillStartLiveResize(_ notification: Notification) {


### PR DESCRIPTION
## Summary

Closes #136.

Fixes the block-based `NotificationCenter` observer lifecycle by keeping the observer tokens returned from registration and removing those tokens explicitly.

## Details

- Changes `NotificationObserver.addObserver` to return the `NSObjectProtocol` observer token.
- Adds token-based removal helpers for individual observers and observer arrays.
- Stores `RulerController` notification observer tokens in `notificationObservers`.
- Removes those tokens in `RulerController.deinit` instead of relying on `removeObserver(self)`.
- Captures `self` weakly in notification callbacks to avoid keeping the controller alive through the observer closure.

## Validation

- `xcodebuild build -project "Free Ruler.xcodeproj" -scheme "Free Ruler" -configuration Debug -derivedDataPath /private/tmp/FreeRulerDerivedData136-notifications`