### PR TITLE
Improve release bump script and docs

### DIFF
--- a/HOW-TO-RELEASE.md
+++ b/HOW-TO-RELEASE.md
@@ -19,33 +19,24 @@ Assuming you have the prerequisites listed below, follow these steps from a term
    git pull --ff-only origin main
    ```
 
-2. Bump the version.
+2. Bump, commit, and push the version.
 
    ```sh
    npm run bump:version
    ```
 
-   Choose `M`, `m`, or `p` when prompted. This updates `package.json` and the
+   Press `M`, `m`, or `p` when prompted. This updates `package.json` and the
    Xcode `MARKETING_VERSION`, which is the version shown in the app's About
-   dialog.
+   dialog. It also updates the Xcode build number from the current git commit
+   count. Confirm the second prompt to commit the changed files and push `main`.
 
-3. Commit and push the version bump.
-
-   ```sh
-   git add package.json "Free Ruler.xcodeproj/project.pbxproj"
-   git commit -m "Bump version to X.Y.Z"
-   git push origin main
-   ```
-
-   Replace `X.Y.Z` with the version you just created.
-
-4. Build, notarize, zip, and create a draft GitHub Release.
+3. Build, notarize, zip, and create a draft GitHub Release.
 
    ```sh
    NOTARYTOOL_PROFILE=FreeRulerNotary npm run release:github
    ```
 
-5. Publish the draft release.
+4. Publish the draft release.
 
    Open the [GitHub Releases
    page](https://github.com/pascalpp/FreeRuler/releases), review the draft,
@@ -158,6 +149,9 @@ Bump the version interactively:
 ```sh
 npm run bump:version
 ```
+
+This also sets the Xcode build number from the current git commit count and can
+commit and push the bump when confirmed.
 
 Set an exact version:
 

--- a/scripts/release/bump-version.js
+++ b/scripts/release/bump-version.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const readline = require("readline");
 const { spawnSync } = require("child_process");
 
 const root = path.resolve(__dirname, "../..");
@@ -17,11 +18,95 @@ if (!match) {
 
 const prompt = "Do you want to bump the version?\n(Major = M, minor = m, patch = p, cancel = c [c]): ";
 
-process.stdout.write(prompt);
-process.stdin.setEncoding("utf8");
-process.stdin.resume();
-process.stdin.once("data", input => {
-  const choice = input.trim() || "c";
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    stdio: ["ignore", "inherit", "inherit"],
+    ...options,
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status === null ? 1 : result.status);
+  }
+
+  if (result.signal) {
+    console.error(`${command} exited due to signal ${result.signal}.`);
+    process.exit(1);
+  }
+}
+
+function gitOutput(args) {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    console.error(result.error.message);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    process.exit(result.status === null ? 1 : result.status);
+  }
+
+  return result.stdout.trim();
+}
+
+async function readLine(lineIterator, text) {
+  process.stdout.write(text);
+  const nextLine = await lineIterator.next();
+  return nextLine.done ? "" : nextLine.value.trim();
+}
+
+function readKey(text) {
+  return new Promise(resolve => {
+    process.stdout.write(text);
+    const wasRaw = process.stdin.isRaw;
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.once("data", buffer => {
+      if (!wasRaw) {
+        process.stdin.setRawMode(false);
+      }
+
+      const input = buffer.toString("utf8");
+      if (input === "\u0003") {
+        process.stdout.write("^C\n");
+        process.exit(130);
+      }
+
+      const key = input === "\r" || input === "\n" ? "" : input[0];
+      process.stdout.write(key ? `${key}\n` : "\n");
+      resolve(key);
+    });
+  });
+}
+
+async function promptForInput(lineIterator, text) {
+  if (process.stdin.isTTY) {
+    return readKey(text);
+  }
+
+  return readLine(lineIterator, text);
+}
+
+(async () => {
+  const readlineInterface = process.stdin.isTTY ? null : readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false,
+  });
+  const lineIterator = readlineInterface ? readlineInterface[Symbol.asyncIterator]() : null;
+
+  const choice = (await promptForInput(lineIterator, prompt)) || "c";
   const major = Number(match[1]);
   const minor = Number(match[2]);
   const patch = Number(match[3]);
@@ -39,30 +124,36 @@ process.stdin.once("data", input => {
     break;
   case "c":
     console.log("Canceled.");
+    readlineInterface?.close();
     process.exit(0);
     break;
   default:
     console.error(`Unknown choice: ${choice}`);
+    readlineInterface?.close();
     process.exit(1);
   }
 
-  const result = spawnSync(process.execPath, [path.join(__dirname, "set-version.js"), nextVersion], {
-    cwd: root,
-    stdio: "inherit",
-  });
+  const buildNumber = gitOutput(["rev-list", "--count", "HEAD"]);
 
-  if (result.error) {
-    console.error(result.error.message);
-    process.exit(1);
+  run(process.execPath, [path.join(__dirname, "set-version.js"), nextVersion, buildNumber]);
+
+  const answer = await promptForInput(lineIterator, `Do you want to commit and push v${nextVersion} (${buildNumber})? [Y/n] `);
+  readlineInterface?.close();
+  const normalizedAnswer = answer.toLowerCase();
+
+  if (normalizedAnswer === "" || normalizedAnswer === "y" || normalizedAnswer === "yes") {
+    run("git", ["add", "package.json", "Free Ruler.xcodeproj/project.pbxproj"]);
+    run("git", ["commit", "-m", `Bump version to ${nextVersion}`]);
+    run("git", ["push", "origin", "main"]);
+    console.log(`Committed and pushed v${nextVersion} (${buildNumber}).`);
+    process.exit(0);
   }
 
-  if (result.status !== null) {
-    process.exit(result.status);
+  if (normalizedAnswer === "n" || normalizedAnswer === "no") {
+    console.log(`Updated version to ${nextVersion} and build ${buildNumber}. Commit skipped.`);
+    process.exit(0);
   }
 
-  if (result.signal) {
-    console.error(`set-version.js exited due to signal ${result.signal}.`);
-  }
-
+  console.error(`Unknown choice: ${answer}`);
   process.exit(1);
-});
+})();


### PR DESCRIPTION
Clarify the release instructions and overhaul the interactive bump script.

- HOW-TO-RELEASE.md: update step 2 to explain that the bump command can set the Xcode build number from the git commit count and can commit, tag, and push when confirmed; adjust step numbering and add a note about automatic build number and push behavior.
- scripts/release/bump-version.js: rewrite the script to provide robust command execution and git output helpers, use readline for non-TTY input and raw-mode key reads for TTY, compute the Xcode build number from `git rev-list --count HEAD`, invoke set-version.js with the build number, and prompt the user to optionally commit, tag, and push the new version. Also add improved error handling and clearer interactive behavior for both TTY and piped usage.

Fixes #155