### PR TITLE
Add RulerCursorController for cursor handling

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -47,6 +47,92 @@ private enum HotkeyBezelLocalizationKey: String {
     }
 }
 
+final class RulerCursorController {
+    enum CursorStyle: Equatable {
+        case arrow
+        case crosshair
+        case openHand
+        case closedHand
+
+        var nsCursor: NSCursor {
+            switch self {
+            case .arrow:
+                return .arrow
+            case .crosshair:
+                return .crosshair
+            case .openHand:
+                return .openHand
+            case .closedHand:
+                return .closedHand
+            }
+        }
+    }
+
+    private var appIsActive = false
+    private var mouseIsOverRuler = false
+    private var mouseIsDraggingRuler = false
+    private let applyCursor: (CursorStyle) -> Void
+
+    private(set) var currentCursor: CursorStyle?
+
+    init(applyCursor: @escaping (CursorStyle) -> Void = { $0.nsCursor.set() }) {
+        self.applyCursor = applyCursor
+    }
+
+    func applicationDidBecomeActive() {
+        appIsActive = true
+        updateCursor()
+    }
+
+    func applicationDidResignActive() {
+        appIsActive = false
+        mouseIsOverRuler = false
+        mouseIsDraggingRuler = false
+        setCursor(.arrow)
+    }
+
+    func mouseEnteredRuler() {
+        mouseIsOverRuler = true
+        updateCursor()
+    }
+
+    func mouseExitedRuler() {
+        mouseIsOverRuler = false
+        updateCursor()
+    }
+
+    func mouseDownInRuler() {
+        mouseIsOverRuler = true
+        mouseIsDraggingRuler = true
+        updateCursor()
+    }
+
+    func mouseUpInRuler(mouseIsInsideRuler: Bool) {
+        mouseIsOverRuler = mouseIsInsideRuler
+        mouseIsDraggingRuler = false
+        updateCursor()
+    }
+
+    private func updateCursor() {
+        guard appIsActive else { return }
+
+        if mouseIsDraggingRuler {
+            setCursor(.closedHand)
+        } else if mouseIsOverRuler {
+            setCursor(.openHand)
+        } else {
+            setCursor(.crosshair)
+        }
+    }
+
+    private func setCursor(_ cursor: CursorStyle) {
+        guard cursor != currentCursor else { return }
+
+        currentCursor = cursor
+        applyCursor(cursor)
+    }
+}
+
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
@@ -58,7 +144,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let foregroundTimerInterval: TimeInterval = 1 / 60 // 60 fps
     let backgroundTimerInterval: TimeInterval = 1 / 30 // 30 fps
 
-    let crosshair = NSCursor.crosshair
+    let rulerCursorController = RulerCursorController()
 
     @IBOutlet weak var pixelsMenuItem: NSMenuItem!
     @IBOutlet weak var millimetersMenuItem: NSMenuItem!
@@ -268,7 +354,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         startTimer(timeInterval: foregroundTimerInterval)
 
-        crosshair.push()
+        rulerCursorController.applicationDidBecomeActive()
     }
 
     func applicationDidResignActive(_ notification: Notification) {
@@ -278,7 +364,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         startTimer(timeInterval: backgroundTimerInterval)
 
-        crosshair.pop()
+        rulerCursorController.applicationDidResignActive()
     }
     
     @IBAction func setUnitPixels(_ sender: Any) {

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -14,10 +14,6 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
 
     var keyListener: Any?
 
-    let openHand = NSCursor.openHand
-    let closedHand = NSCursor.closedHand
-    let crosshair = NSCursor.crosshair
-
     var preferencesWindowOpen = false {
         didSet {
             updateIsFloatingPanel()
@@ -102,20 +98,19 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     override func mouseEntered(with event: NSEvent) {
-        openHand.push()
+        rulerCursorController?.mouseEnteredRuler()
     }
 
     override func mouseExited(with event: NSEvent) {
-        openHand.pop()
-        crosshair.push()
+        rulerCursorController?.mouseExitedRuler()
     }
 
     override func mouseDown(with event: NSEvent) {
-        closedHand.push()
-}
+        rulerCursorController?.mouseDownInRuler()
+    }
 
     override func mouseUp(with event: NSEvent) {
-        closedHand.pop()
+        rulerCursorController?.mouseUpInRuler(mouseIsInsideRuler: isMouseInsideRuler(with: event))
     }
 
     override func mouseMoved(with event: NSEvent) {
@@ -130,6 +125,15 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     func enableMouseTicks() {
         rulerWindow.rule.showMouseTick = true
         otherWindow?.rule.showMouseTick = true
+    }
+
+    private var rulerCursorController: RulerCursorController? {
+        return (NSApp.delegate as? AppDelegate)?.rulerCursorController
+    }
+
+    private func isMouseInsideRuler(with event: NSEvent) -> Bool {
+        let location = rulerWindow.rule.convert(event.locationInWindow, from: nil)
+        return rulerWindow.rule.bounds.contains(location)
     }
 
     func onChangeGrouped() {

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -48,4 +48,60 @@ final class RulerCoreTests: XCTestCase {
         XCTAssertEqual(horizontal.minY, screenHeight - 90.0, accuracy: 0.0001)
         XCTAssertEqual(vertical.maxY, horizontal.minY + 1.0, accuracy: 0.0001)
     }
+
+    func testRulerCursorControllerChoosesCursorForActiveRulerEvents() {
+        var appliedCursors: [RulerCursorController.CursorStyle] = []
+        let controller = RulerCursorController { appliedCursors.append($0) }
+
+        controller.applicationDidBecomeActive()
+        controller.mouseEnteredRuler()
+        controller.mouseDownInRuler()
+        controller.mouseUpInRuler(mouseIsInsideRuler: true)
+        controller.mouseExitedRuler()
+
+        XCTAssertEqual(appliedCursors, [
+            .crosshair,
+            .openHand,
+            .closedHand,
+            .openHand,
+            .crosshair,
+        ])
+    }
+
+    func testRulerCursorControllerReturnsToCrosshairWhenDragEndsOutsideRuler() {
+        var appliedCursors: [RulerCursorController.CursorStyle] = []
+        let controller = RulerCursorController { appliedCursors.append($0) }
+
+        controller.applicationDidBecomeActive()
+        controller.mouseEnteredRuler()
+        controller.mouseDownInRuler()
+        controller.mouseExitedRuler()
+        controller.mouseUpInRuler(mouseIsInsideRuler: false)
+
+        XCTAssertEqual(appliedCursors, [
+            .crosshair,
+            .openHand,
+            .closedHand,
+            .crosshair,
+        ])
+    }
+
+    func testRulerCursorControllerResetsWhenAppResignsActive() {
+        var appliedCursors: [RulerCursorController.CursorStyle] = []
+        let controller = RulerCursorController { appliedCursors.append($0) }
+
+        controller.applicationDidBecomeActive()
+        controller.mouseEnteredRuler()
+        controller.mouseDownInRuler()
+        controller.applicationDidResignActive()
+        controller.applicationDidBecomeActive()
+
+        XCTAssertEqual(appliedCursors, [
+            .crosshair,
+            .openHand,
+            .closedHand,
+            .arrow,
+            .crosshair,
+        ])
+    }
 }


### PR DESCRIPTION
Introduce RulerCursorController to centralize cursor state and transitions (arrow, crosshair, openHand, closedHand) and replace direct NSCursor push/pop usage. Integrate controller into AppDelegate and RulerController, wire mouseEntered/mouseExited/mouseDown/mouseUp to the new API, and add isMouseInsideRuler helper to determine mouse-up behavior. Add unit tests verifying cursor sequences for active/inactive and drag scenarios. This clarifies cursor logic and ensures consistent behavior across app lifecycle changes.

Fixes #134