### PR TITLE
[codex] Narrow mouse tick polling

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		50A147032D03C00000147C0D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 50A137022D03A00000137C0D /* XCTest.framework */; };
 		50B146262D03B00000146C0D /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 50B146202D03B00000146C0D /* Localizable.xcstrings */; };
 		50B149012D04A00000149C0D /* HotkeyBezel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B149002D04A00000149C0D /* HotkeyBezel.swift */; };
+		50B1D3512D05D00000B1D135 /* MouseTickTimerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1D3502D05D00000B1D135 /* MouseTickTimerPolicy.swift */; };
+		50B1D3532D05D00100B1D135 /* RulerCursorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1D3522D05D00100B1D135 /* RulerCursorController.swift */; };
 		50C6D891228BDBAD0091F19E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50C6D890228BDBAD0091F19E /* Images.xcassets */; };
 		50CCB206227FCD26004645C5 /* AppIconLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CCB205227FCD26004645C5 /* AppIconLayout.swift */; };
 		50D7BEE7227D42FD0008B95E /* RulerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEE6227D42FD0008B95E /* RulerController.swift */; };
@@ -81,6 +83,8 @@
 		50A147022D03C00000147C0D /* FreeRulerUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FreeRulerUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		50B146202D03B00000146C0D /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		50B149002D04A00000149C0D /* HotkeyBezel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyBezel.swift; sourceTree = "<group>"; };
+		50B1D3502D05D00000B1D135 /* MouseTickTimerPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseTickTimerPolicy.swift; sourceTree = "<group>"; };
+		50B1D3522D05D00100B1D135 /* RulerCursorController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RulerCursorController.swift; sourceTree = "<group>"; };
 		50C6D890228BDBAD0091F19E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		50CCB205227FCD26004645C5 /* AppIconLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconLayout.swift; sourceTree = "<group>"; };
 		50D7BEE6227D42FD0008B95E /* RulerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RulerController.swift; sourceTree = "<group>"; };
@@ -184,6 +188,8 @@
 				507FED5F2280E13200BD77DC /* Prefs.swift */,
 				50008B6022846FCD001E3EE4 /* Notifications.swift */,
 				6F4102882260712F00F06A10 /* AppDelegate.swift */,
+				50B1D3522D05D00100B1D135 /* RulerCursorController.swift */,
+				50B1D3502D05D00000B1D135 /* MouseTickTimerPolicy.swift */,
 				50B149002D04A00000149C0D /* HotkeyBezel.swift */,
 				6F41028C2260713100F06A10 /* MainMenu.xib */,
 				50B146202D03B00000146C0D /* Localizable.xcstrings */,
@@ -363,6 +369,8 @@
 				507FED602280E13200BD77DC /* Prefs.swift in Sources */,
 				50CCB206227FCD26004645C5 /* AppIconLayout.swift in Sources */,
 				50B149012D04A00000149C0D /* HotkeyBezel.swift in Sources */,
+				50B1D3532D05D00100B1D135 /* RulerCursorController.swift in Sources */,
+				50B1D3512D05D00000B1D135 /* MouseTickTimerPolicy.swift in Sources */,
 				6F41029F22607DC900F06A10 /* HorizontalRule.swift in Sources */,
 				50D7BEEB227D432E0008B95E /* RulerWindow.swift in Sources */,
 				507FED43227FFF5300BD77DC /* PreferencesController.swift in Sources */,

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -47,92 +47,6 @@ private enum HotkeyBezelLocalizationKey: String {
     }
 }
 
-final class RulerCursorController {
-    enum CursorStyle: Equatable {
-        case arrow
-        case crosshair
-        case openHand
-        case closedHand
-
-        var nsCursor: NSCursor {
-            switch self {
-            case .arrow:
-                return .arrow
-            case .crosshair:
-                return .crosshair
-            case .openHand:
-                return .openHand
-            case .closedHand:
-                return .closedHand
-            }
-        }
-    }
-
-    private var appIsActive = false
-    private var mouseIsOverRuler = false
-    private var mouseIsDraggingRuler = false
-    private let applyCursor: (CursorStyle) -> Void
-
-    private(set) var currentCursor: CursorStyle?
-
-    init(applyCursor: @escaping (CursorStyle) -> Void = { $0.nsCursor.set() }) {
-        self.applyCursor = applyCursor
-    }
-
-    func applicationDidBecomeActive() {
-        appIsActive = true
-        updateCursor()
-    }
-
-    func applicationDidResignActive() {
-        appIsActive = false
-        mouseIsOverRuler = false
-        mouseIsDraggingRuler = false
-        setCursor(.arrow)
-    }
-
-    func mouseEnteredRuler() {
-        mouseIsOverRuler = true
-        updateCursor()
-    }
-
-    func mouseExitedRuler() {
-        mouseIsOverRuler = false
-        updateCursor()
-    }
-
-    func mouseDownInRuler() {
-        mouseIsOverRuler = true
-        mouseIsDraggingRuler = true
-        updateCursor()
-    }
-
-    func mouseUpInRuler(mouseIsInsideRuler: Bool) {
-        mouseIsOverRuler = mouseIsInsideRuler
-        mouseIsDraggingRuler = false
-        updateCursor()
-    }
-
-    private func updateCursor() {
-        guard appIsActive else { return }
-
-        if mouseIsDraggingRuler {
-            setCursor(.closedHand)
-        } else if mouseIsOverRuler {
-            setCursor(.openHand)
-        } else {
-            setCursor(.crosshair)
-        }
-    }
-
-    private func setCursor(_ cursor: CursorStyle) {
-        guard cursor != currentCursor else { return }
-
-        currentCursor = cursor
-        applyCursor(cursor)
-    }
-}
-
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
@@ -141,10 +55,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var rulers: [RulerController] = []
 
     var timer: Timer?
+    private var timerInterval: TimeInterval?
     let foregroundTimerInterval: TimeInterval = 1 / 60 // 60 fps
     let backgroundTimerInterval: TimeInterval = 1 / 30 // 30 fps
 
     let rulerCursorController = RulerCursorController()
+    lazy var mouseTickTimerPolicy = MouseTickTimerPolicy(
+        foregroundInterval: foregroundTimerInterval,
+        backgroundInterval: backgroundTimerInterval
+    )
 
     @IBOutlet weak var pixelsMenuItem: NSMenuItem!
     @IBOutlet weak var millimetersMenuItem: NSMenuItem!
@@ -285,6 +204,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             detachRulerWindow(ruler.rulerWindow)
             ruler.rulerWindow.orderOut(self)
             updateRulerGrouping()
+            updateMouseTickTimer()
         } else {
             showRuler(ruler)
         }
@@ -309,6 +229,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         ruler.showWindow(self)
         ruler.rulerWindow.orderFrontRegardless()
         updateRulerGrouping()
+        updateMouseTickTimer()
     }
 
     private func detachRulerWindow(_ window: RulerWindow) {
@@ -352,7 +273,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             ruler.foreground()
         }
 
-        startTimer(timeInterval: foregroundTimerInterval)
+        mouseTickTimerPolicy.applicationDidBecomeActive()
+        updateMouseTickTimer()
 
         rulerCursorController.applicationDidBecomeActive()
     }
@@ -362,7 +284,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             ruler.background()
         }
 
-        startTimer(timeInterval: backgroundTimerInterval)
+        mouseTickTimerPolicy.applicationDidResignActive()
+        updateMouseTickTimer()
 
         rulerCursorController.applicationDidResignActive()
     }
@@ -555,8 +478,32 @@ extension AppDelegate: NSMenuItemValidation {
 // MARK: - Timer
 extension AppDelegate {
 
+    func suspendMouseTickUpdates(owner: AnyObject) {
+        mouseTickTimerPolicy.suspend(owner: owner)
+        updateMouseTickTimer()
+    }
+
+    func resumeMouseTickUpdates(owner: AnyObject) {
+        mouseTickTimerPolicy.resume(owner: owner)
+        updateMouseTickTimer()
+    }
+
+    private func updateMouseTickTimer() {
+        mouseTickTimerPolicy.updateVisibleRulers(hasVisibleRuler)
+
+        guard let timeInterval = mouseTickTimerPolicy.desiredInterval else {
+            stopTimer()
+            return
+        }
+
+        startTimer(timeInterval: timeInterval)
+    }
+
     private func startTimer(timeInterval: TimeInterval) {
+        guard timer == nil || timerInterval != timeInterval else { return }
+
         timer?.invalidate()
+        timerInterval = timeInterval
 
         timer = Timer.scheduledTimer(
             timeInterval: timeInterval,
@@ -565,6 +512,12 @@ extension AppDelegate {
             userInfo: nil,
             repeats: true
         )
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+        timerInterval = nil
     }
 
     @objc func onInterval() {

--- a/Free Ruler/MouseTickTimerPolicy.swift
+++ b/Free Ruler/MouseTickTimerPolicy.swift
@@ -7,7 +7,7 @@ final class MouseTickTimerPolicy {
     private var hasApplicationState = false
     private var appIsActive = false
     private var hasVisibleRulers = false
-    private var suspendedOwners: Set<ObjectIdentifier> = []
+    private let suspendedOwners = NSHashTable<AnyObject>.weakObjects()
 
     init(foregroundInterval: TimeInterval, backgroundInterval: TimeInterval) {
         self.foregroundInterval = foregroundInterval
@@ -15,7 +15,7 @@ final class MouseTickTimerPolicy {
     }
 
     var desiredInterval: TimeInterval? {
-        guard hasApplicationState, hasVisibleRulers, suspendedOwners.isEmpty else { return nil }
+        guard hasApplicationState, hasVisibleRulers, suspendedOwners.allObjects.isEmpty else { return nil }
         return appIsActive ? foregroundInterval : backgroundInterval
     }
 
@@ -34,10 +34,10 @@ final class MouseTickTimerPolicy {
     }
 
     func suspend(owner: AnyObject) {
-        suspendedOwners.insert(ObjectIdentifier(owner))
+        suspendedOwners.add(owner)
     }
 
     func resume(owner: AnyObject) {
-        suspendedOwners.remove(ObjectIdentifier(owner))
+        suspendedOwners.remove(owner)
     }
 }

--- a/Free Ruler/MouseTickTimerPolicy.swift
+++ b/Free Ruler/MouseTickTimerPolicy.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+final class MouseTickTimerPolicy {
+    let foregroundInterval: TimeInterval
+    let backgroundInterval: TimeInterval
+
+    private var hasApplicationState = false
+    private var appIsActive = false
+    private var hasVisibleRulers = false
+    private var suspendedOwners: Set<ObjectIdentifier> = []
+
+    init(foregroundInterval: TimeInterval, backgroundInterval: TimeInterval) {
+        self.foregroundInterval = foregroundInterval
+        self.backgroundInterval = backgroundInterval
+    }
+
+    var desiredInterval: TimeInterval? {
+        guard hasApplicationState, hasVisibleRulers, suspendedOwners.isEmpty else { return nil }
+        return appIsActive ? foregroundInterval : backgroundInterval
+    }
+
+    func applicationDidBecomeActive() {
+        hasApplicationState = true
+        appIsActive = true
+    }
+
+    func applicationDidResignActive() {
+        hasApplicationState = true
+        appIsActive = false
+    }
+
+    func updateVisibleRulers(_ hasVisibleRulers: Bool) {
+        self.hasVisibleRulers = hasVisibleRulers
+        if !hasVisibleRulers {
+            suspendedOwners.removeAll()
+        }
+    }
+
+    func suspend(owner: AnyObject) {
+        suspendedOwners.insert(ObjectIdentifier(owner))
+    }
+
+    func resume(owner: AnyObject) {
+        suspendedOwners.remove(ObjectIdentifier(owner))
+    }
+}

--- a/Free Ruler/MouseTickTimerPolicy.swift
+++ b/Free Ruler/MouseTickTimerPolicy.swift
@@ -31,9 +31,6 @@ final class MouseTickTimerPolicy {
 
     func updateVisibleRulers(_ hasVisibleRulers: Bool) {
         self.hasVisibleRulers = hasVisibleRulers
-        if !hasVisibleRulers {
-            suspendedOwners.removeAll()
-        }
     }
 
     func suspend(owner: AnyObject) {

--- a/Free Ruler/MouseTickTimerPolicy.swift
+++ b/Free Ruler/MouseTickTimerPolicy.swift
@@ -15,8 +15,13 @@ final class MouseTickTimerPolicy {
     }
 
     var desiredInterval: TimeInterval? {
-        guard hasApplicationState, hasVisibleRulers, suspendedOwners.allObjects.isEmpty else { return nil }
+        guard hasApplicationState, hasVisibleRulers, !hasSuspendedOwners else { return nil }
         return appIsActive ? foregroundInterval : backgroundInterval
+    }
+
+    private var hasSuspendedOwners: Bool {
+        guard suspendedOwners.count > 0 else { return false }
+        return suspendedOwners.anyObject != nil
     }
 
     func applicationDidBecomeActive() {

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -13,6 +13,8 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     var otherWindow: RulerWindow?
 
     var keyListener: Any?
+    private var mouseTickResumeTimer: Timer?
+    private let mouseTickResumeDelay: TimeInterval = 0.15
 
     var preferencesWindowOpen = false {
         didSet {
@@ -57,6 +59,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     deinit {
+        mouseTickResumeTimer?.invalidate()
         removeObservers(&notificationObservers)
     }
 
@@ -80,12 +83,14 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     func windowWillMove(_ notification: Notification) {
+        mouseTickResumeTimer?.invalidate()
+        mouseTickResumeTimer = nil
         disableMouseTicks()
     }
 
     func windowDidMove(_ notification: Notification) {
         rulerWindow.invalidateShadow()
-        enableMouseTicks()
+        scheduleMouseTickResume()
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
@@ -128,6 +133,17 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
         rulerWindow.rule.showMouseTick = true
         otherWindow?.rule.showMouseTick = true
         appDelegate?.resumeMouseTickUpdates(owner: self)
+    }
+
+    private func scheduleMouseTickResume() {
+        mouseTickResumeTimer?.invalidate()
+        mouseTickResumeTimer = Timer.scheduledTimer(
+            withTimeInterval: mouseTickResumeDelay,
+            repeats: false
+        ) { [weak self] _ in
+            self?.enableMouseTicks()
+            self?.mouseTickResumeTimer = nil
+        }
     }
 
     private var rulerCursorController: RulerCursorController? {

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -85,6 +85,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
 
     func windowDidMove(_ notification: Notification) {
         rulerWindow.invalidateShadow()
+        enableMouseTicks()
     }
 
     func windowDidBecomeKey(_ notification: Notification) {

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -120,15 +120,21 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     func disableMouseTicks() {
         rulerWindow.rule.showMouseTick = false
         otherWindow?.rule.showMouseTick = false
+        appDelegate?.suspendMouseTickUpdates(owner: self)
     }
 
     func enableMouseTicks() {
         rulerWindow.rule.showMouseTick = true
         otherWindow?.rule.showMouseTick = true
+        appDelegate?.resumeMouseTickUpdates(owner: self)
     }
 
     private var rulerCursorController: RulerCursorController? {
-        return (NSApp.delegate as? AppDelegate)?.rulerCursorController
+        return appDelegate?.rulerCursorController
+    }
+
+    private var appDelegate: AppDelegate? {
+        return NSApp.delegate as? AppDelegate
     }
 
     private func isMouseInsideRuler(with event: NSEvent) -> Bool {

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -83,8 +83,6 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     func windowWillMove(_ notification: Notification) {
-        mouseTickResumeTimer?.invalidate()
-        mouseTickResumeTimer = nil
         disableMouseTicks()
     }
 
@@ -124,6 +122,8 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     func disableMouseTicks() {
+        mouseTickResumeTimer?.invalidate()
+        mouseTickResumeTimer = nil
         rulerWindow.rule.showMouseTick = false
         otherWindow?.rule.showMouseTick = false
         appDelegate?.suspendMouseTickUpdates(owner: self)

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -130,6 +130,8 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     func enableMouseTicks() {
+        guard !rulerWindow.rule.showMouseTick || otherWindow?.rule.showMouseTick == false else { return }
+
         rulerWindow.rule.showMouseTick = true
         otherWindow?.rule.showMouseTick = true
         appDelegate?.resumeMouseTickUpdates(owner: self)

--- a/Free Ruler/RulerCursorController.swift
+++ b/Free Ruler/RulerCursorController.swift
@@ -1,0 +1,87 @@
+import Cocoa
+
+final class RulerCursorController {
+    enum CursorStyle: Equatable {
+        case arrow
+        case crosshair
+        case openHand
+        case closedHand
+
+        var nsCursor: NSCursor {
+            switch self {
+            case .arrow:
+                return .arrow
+            case .crosshair:
+                return .crosshair
+            case .openHand:
+                return .openHand
+            case .closedHand:
+                return .closedHand
+            }
+        }
+    }
+
+    private var appIsActive = false
+    private var mouseIsOverRuler = false
+    private var mouseIsDraggingRuler = false
+    private let applyCursor: (CursorStyle) -> Void
+
+    private(set) var currentCursor: CursorStyle?
+
+    init(applyCursor: @escaping (CursorStyle) -> Void = { $0.nsCursor.set() }) {
+        self.applyCursor = applyCursor
+    }
+
+    func applicationDidBecomeActive() {
+        appIsActive = true
+        updateCursor()
+    }
+
+    func applicationDidResignActive() {
+        appIsActive = false
+        mouseIsOverRuler = false
+        mouseIsDraggingRuler = false
+        setCursor(.arrow)
+    }
+
+    func mouseEnteredRuler() {
+        mouseIsOverRuler = true
+        updateCursor()
+    }
+
+    func mouseExitedRuler() {
+        mouseIsOverRuler = false
+        updateCursor()
+    }
+
+    func mouseDownInRuler() {
+        mouseIsOverRuler = true
+        mouseIsDraggingRuler = true
+        updateCursor()
+    }
+
+    func mouseUpInRuler(mouseIsInsideRuler: Bool) {
+        mouseIsOverRuler = mouseIsInsideRuler
+        mouseIsDraggingRuler = false
+        updateCursor()
+    }
+
+    private func updateCursor() {
+        guard appIsActive else { return }
+
+        if mouseIsDraggingRuler {
+            setCursor(.closedHand)
+        } else if mouseIsOverRuler {
+            setCursor(.openHand)
+        } else {
+            setCursor(.crosshair)
+        }
+    }
+
+    private func setCursor(_ cursor: CursorStyle) {
+        guard cursor != currentCursor else { return }
+
+        currentCursor = cursor
+        applyCursor(cursor)
+    }
+}

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -104,4 +104,39 @@ final class RulerCoreTests: XCTestCase {
             .crosshair,
         ])
     }
+
+    func testMouseTickTimerPolicyRunsOnlyWhenRulersAreVisible() {
+        let policy = MouseTickTimerPolicy(foregroundInterval: 1 / 60, backgroundInterval: 1 / 30)
+
+        policy.applicationDidBecomeActive()
+        XCTAssertNil(policy.desiredInterval)
+
+        policy.updateVisibleRulers(true)
+        XCTAssertEqual(policy.desiredInterval, 1 / 60)
+
+        policy.applicationDidResignActive()
+        XCTAssertEqual(policy.desiredInterval, 1 / 30)
+
+        policy.updateVisibleRulers(false)
+        XCTAssertNil(policy.desiredInterval)
+    }
+
+    func testMouseTickTimerPolicySuspendsUntilAllOwnersResume() {
+        let policy = MouseTickTimerPolicy(foregroundInterval: 1 / 60, backgroundInterval: 1 / 30)
+        let firstOwner = NSObject()
+        let secondOwner = NSObject()
+
+        policy.applicationDidBecomeActive()
+        policy.updateVisibleRulers(true)
+
+        policy.suspend(owner: firstOwner)
+        policy.suspend(owner: secondOwner)
+        XCTAssertNil(policy.desiredInterval)
+
+        policy.resume(owner: firstOwner)
+        XCTAssertNil(policy.desiredInterval)
+
+        policy.resume(owner: secondOwner)
+        XCTAssertEqual(policy.desiredInterval, 1 / 60)
+    }
 }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -139,4 +139,22 @@ final class RulerCoreTests: XCTestCase {
         policy.resume(owner: secondOwner)
         XCTAssertEqual(policy.desiredInterval, 1 / 60)
     }
+
+    func testMouseTickTimerPolicyKeepsSuspensionAcrossVisibilityChanges() {
+        let policy = MouseTickTimerPolicy(foregroundInterval: 1 / 60, backgroundInterval: 1 / 30)
+        let owner = NSObject()
+
+        policy.applicationDidBecomeActive()
+        policy.updateVisibleRulers(true)
+        policy.suspend(owner: owner)
+
+        policy.updateVisibleRulers(false)
+        XCTAssertNil(policy.desiredInterval)
+
+        policy.updateVisibleRulers(true)
+        XCTAssertNil(policy.desiredInterval)
+
+        policy.resume(owner: owner)
+        XCTAssertEqual(policy.desiredInterval, 1 / 60)
+    }
 }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -157,4 +157,19 @@ final class RulerCoreTests: XCTestCase {
         policy.resume(owner: owner)
         XCTAssertEqual(policy.desiredInterval, 1 / 60)
     }
+
+    func testMouseTickTimerPolicyClearsSuspensionWhenOwnerDeallocates() {
+        let policy = MouseTickTimerPolicy(foregroundInterval: 1 / 60, backgroundInterval: 1 / 30)
+
+        policy.applicationDidBecomeActive()
+        policy.updateVisibleRulers(true)
+
+        autoreleasepool {
+            let owner = NSObject()
+            policy.suspend(owner: owner)
+            XCTAssertNil(policy.desiredInterval)
+        }
+
+        XCTAssertEqual(policy.desiredInterval, 1 / 60)
+    }
 }


### PR DESCRIPTION
## Summary

- Move `MouseTickTimerPolicy` and `RulerCursorController` out of `AppDelegate` into focused source files.
- Stop the mouse tick timer when no rulers are visible or when ruler interactions have explicitly suspended mouse tick updates.
- Track the active timer interval so foreground/background transitions do not recreate equivalent timers unnecessarily.
- Add core tests for visible-ruler timer behavior and multi-owner suspension handling.

## Why

Issue #135 calls out that active mouse-position polling should be replaced or narrowed. This narrows it by centralizing the timer decision in a small policy object and stopping polling while there is no visible ruler or while ruler mouse tick rendering is disabled during ruler interactions.

## Validation

- `xcodebuild test -project "Free Ruler.xcodeproj" -scheme "Free Ruler" -destination 'platform=macOS' -derivedDataPath /private/tmp/FreeRulerDerivedData-issue135`

Fixes #135