### PR TITLE
Handle Command-W to close key window or ruler

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -201,10 +201,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if ruler.rulerWindow.isVisible {
-            detachRulerWindow(ruler.rulerWindow)
-            ruler.rulerWindow.orderOut(self)
-            updateRulerGrouping()
-            updateMouseTickTimer()
+            hideRuler(ruler)
         } else {
             showRuler(ruler)
         }
@@ -228,6 +225,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func showRuler(_ ruler: RulerController) {
         ruler.showWindow(self)
         ruler.rulerWindow.orderFrontRegardless()
+        updateRulerGrouping()
+        updateMouseTickTimer()
+    }
+
+    private func hideRuler(_ ruler: RulerController) {
+        detachRulerWindow(ruler.rulerWindow)
+        ruler.rulerWindow.orderOut(self)
         updateRulerGrouping()
         updateMouseTickTimer()
     }
@@ -342,9 +346,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    @IBAction func closePreferences(_ sender: Any) {
-        guard preferencesController?.window?.isKeyWindow == true else { return }
-        preferencesController?.close()
+    @IBAction func closeKeyWindow(_ sender: Any) {
+        if let ruler = rulers.first(where: { $0.rulerWindow.isKeyWindow }) {
+            if prefs.groupRulers {
+                prefs.groupRulers = false
+                detachRulerWindows()
+            }
+
+            hideRuler(ruler)
+            return
+        }
+
+        NSApp.keyWindow?.performClose(sender)
     }
 
     @IBAction func alignRulersAtMouseLocation(_ sender: Any) {
@@ -449,8 +462,8 @@ extension AppDelegate: NSMenuItemValidation {
 
     func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
         switch menuItem.action {
-        case #selector(closePreferences(_:)):
-            return preferencesController?.window?.isKeyWindow == true
+        case #selector(closeKeyWindow(_:)):
+            return NSApp.keyWindow?.isVisible == true
         case #selector(toggleHorizontalRuler(_:)):
             let ruler = existingRulerController(orientation: .horizontal)
             menuItem.title = ruler?.rulerWindow.isVisible == true

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -226,7 +226,7 @@
                         <items>
                             <menuItem title="Close" keyEquivalent="w" id="n0M-rw-v5l">
                                 <connections>
-                                    <action selector="closePreferences:" target="Voe-Tx-rLC" id="X4C-ak-CJh"/>
+                                    <action selector="closeKeyWindow:" target="Voe-Tx-rLC" id="X4C-ak-CJh"/>
                                 </connections>
                             </menuItem>
                             <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">

--- a/FreeRulerUITests/FreeRulerUITests.swift
+++ b/FreeRulerUITests/FreeRulerUITests.swift
@@ -89,12 +89,13 @@ final class FreeRulerUITests: XCTestCase {
 
     func testRulerCloseWithCommandW() {
         XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+        XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))
 
         horizontalRuler.click()
         app.typeKey("w", modifierFlags: .command)
 
         XCTAssertTrue(horizontalRuler.waitForNonExistence(timeout: 2))
-    }
+        XCTAssertTrue(verticalRuler.exists)
 
     func testHiddenRulersCanBeRestoredAndResetRestoresVisibility() {
         XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))

--- a/FreeRulerUITests/FreeRulerUITests.swift
+++ b/FreeRulerUITests/FreeRulerUITests.swift
@@ -87,6 +87,15 @@ final class FreeRulerUITests: XCTestCase {
         XCTAssertTrue(preferences.waitForNonExistence(timeout: 2))
     }
 
+    func testRulerCloseWithCommandW() {
+        XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
+
+        horizontalRuler.click()
+        app.typeKey("w", modifierFlags: .command)
+
+        XCTAssertTrue(horizontalRuler.waitForNonExistence(timeout: 2))
+    }
+
     func testHiddenRulersCanBeRestoredAndResetRestoresVisibility() {
         XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))
         XCTAssertTrue(verticalRuler.waitForExistence(timeout: 3))

--- a/FreeRulerUITests/FreeRulerUITests.swift
+++ b/FreeRulerUITests/FreeRulerUITests.swift
@@ -96,6 +96,7 @@ final class FreeRulerUITests: XCTestCase {
 
         XCTAssertTrue(horizontalRuler.waitForNonExistence(timeout: 2))
         XCTAssertTrue(verticalRuler.exists)
+    }
 
     func testHiddenRulersCanBeRestoredAndResetRestoresVisibility() {
         XCTAssertTrue(horizontalRuler.waitForExistence(timeout: 3))


### PR DESCRIPTION
Refactor hiding logic into a new hideRuler(_:) helper and replace closePreferences(_: ) with closeKeyWindow(_: ). The new action will close the focused ruler (ungrouping if needed) or forward to the key window's performClose. Update validateMenuItem to reflect the new selector and update MainMenu.xib to use closeKeyWindow:. Add a UI test (testRulerCloseWithCommandW) to assert Command-W closes a visible ruler.

Fixes #158