### PR TITLE
[codex] Add Sparkle auto-update release flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 xcuserdata
 .DS_Store
+.env
 build/
 dist/*.zip
 .*bak

--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -41,7 +41,6 @@
 		50FC527E25BF326800B84228 /* FreeRuler.help in Resources */ = {isa = PBXBuildFile; fileRef = 50FC527D25BF326800B84228 /* FreeRuler.help */; };
 		56B1A9290A8ADEA46E1D3129 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
 		5B52743D84FFD5EBF40B8558 /* VerticalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5012CAAC226AB09000BD9565 /* VerticalRule.swift */; };
-		606AF9DF663B5C9F1444D88B /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EAAF2519700045F2E236E44 /* Cocoa.framework */; };
 		6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4102882260712F00F06A10 /* AppDelegate.swift */; };
 		6F41028E2260713100F06A10 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41028C2260713100F06A10 /* MainMenu.xib */; };
 		6F41029F22607DC900F06A10 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
@@ -95,7 +94,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0EAAF2519700045F2E236E44 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		50008B6022846FCD001E3EE4 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		5012CAAC226AB09000BD9565 /* VerticalRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalRule.swift; sourceTree = "<group>"; };
 		507FED41227FFF5300BD77DC /* PreferencesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesController.swift; sourceTree = "<group>"; };
@@ -164,7 +162,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				606AF9DF663B5C9F1444D88B /* Cocoa.framework in Frameworks */,
 				DA8EDBA823F8AC60DD774681 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -200,7 +197,6 @@
 		637D287E638FC2DDD19B0FC8 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
-				0EAAF2519700045F2E236E44 /* Cocoa.framework */,
 			);
 			name = "OS X";
 			sourceTree = "<group>";

--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -7,6 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		012078ADCF85378A053BB9FA /* HotkeyBezel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B149002D04A00000149C0D /* HotkeyBezel.swift */; };
+		0C56237FE08F4155F0B63FFB /* RulerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEE6227D42FD0008B95E /* RulerController.swift */; };
+		18769743B3FCD2594B0B8CF2 /* PreferencesController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 507FED42227FFF5300BD77DC /* PreferencesController.xib */; };
+		2075141A6742AF52598D0314 /* Prefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507FED5F2280E13200BD77DC /* Prefs.swift */; };
+		23E2B80975F07733EB6CF5DB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4102882260712F00F06A10 /* AppDelegate.swift */; };
+		274FA3FF1BA7829144BBEB70 /* RulerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEEA227D432E0008B95E /* RulerWindow.swift */; };
+		29E0CF116F5BCEA78DEA46BC /* RulerCursorController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1D3522D05D00100B1D135 /* RulerCursorController.swift */; };
+		2AAC34C01BE64CE025D5619D /* AppIconLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50CCB205227FCD26004645C5 /* AppIconLayout.swift */; };
+		2AFB3AE0D34FF01F00F671D4 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41028C2260713100F06A10 /* MainMenu.xib */; };
+		2ED12254704310C00A527F07 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 50B146202D03B00000146C0D /* Localizable.xcstrings */; };
+		378A15CD2C8708C2F8CB62E7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50C6D890228BDBAD0091F19E /* Images.xcassets */; };
 		50008B6122846FCD001E3EE4 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50008B6022846FCD001E3EE4 /* Notifications.swift */; };
 		5012CAAD226AB09000BD9565 /* VerticalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5012CAAC226AB09000BD9565 /* VerticalRule.swift */; };
 		507FED43227FFF5300BD77DC /* PreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507FED41227FFF5300BD77DC /* PreferencesController.swift */; };
@@ -28,9 +39,20 @@
 		50D7BEEB227D432E0008B95E /* RulerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEEA227D432E0008B95E /* RulerWindow.swift */; };
 		50D7BEED227D5C810008B95E /* RuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEEC227D5C810008B95E /* RuleView.swift */; };
 		50FC527E25BF326800B84228 /* FreeRuler.help in Resources */ = {isa = PBXBuildFile; fileRef = 50FC527D25BF326800B84228 /* FreeRuler.help */; };
+		56B1A9290A8ADEA46E1D3129 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
+		5B52743D84FFD5EBF40B8558 /* VerticalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5012CAAC226AB09000BD9565 /* VerticalRule.swift */; };
+		606AF9DF663B5C9F1444D88B /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0EAAF2519700045F2E236E44 /* Cocoa.framework */; };
 		6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4102882260712F00F06A10 /* AppDelegate.swift */; };
 		6F41028E2260713100F06A10 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6F41028C2260713100F06A10 /* MainMenu.xib */; };
 		6F41029F22607DC900F06A10 /* HorizontalRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F41029E22607DC900F06A10 /* HorizontalRule.swift */; };
+		9A082BBC4A583513B0858C41 /* RuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEEC227D5C810008B95E /* RuleView.swift */; };
+		B06EA4AC302536E25093D003 /* RulerTickLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1D3542D05E00000B1D138 /* RulerTickLayout.swift */; };
+		C47EEBC81CE13FEB9A2ADE5A /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50008B6022846FCD001E3EE4 /* Notifications.swift */; };
+		CD78B999536A29591C97FB80 /* MouseTickTimerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B1D3502D05D00000B1D135 /* MouseTickTimerPolicy.swift */; };
+		DA8EDBA823F8AC60DD774681 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 7201D59F68C1B65518A4C10A /* Sparkle */; };
+		E6BC6663BAF0D11D7A9D2195 /* Ruler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D7BEE8227D43270008B95E /* Ruler.swift */; };
+		E9A35F3EE51A34DFC9D6097E /* FreeRuler.help in Resources */ = {isa = PBXBuildFile; fileRef = 50FC527D25BF326800B84228 /* FreeRuler.help */; };
+		F73A5B5C974E514FD2663412 /* PreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507FED41227FFF5300BD77DC /* PreferencesController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +95,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0EAAF2519700045F2E236E44 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		50008B6022846FCD001E3EE4 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		5012CAAC226AB09000BD9565 /* VerticalRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalRule.swift; sourceTree = "<group>"; };
 		507FED41227FFF5300BD77DC /* PreferencesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesController.swift; sourceTree = "<group>"; };
@@ -96,6 +119,7 @@
 		50FC527D25BF326800B84228 /* FreeRuler.help */ = {isa = PBXFileReference; lastKnownFileType = folder; path = FreeRuler.help; sourceTree = "<group>"; };
 		53AF6A4225A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		53AF6A4325A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/PreferencesController.strings; sourceTree = "<group>"; };
+		55ACACE1604925BB61E9D74C /* Info.github.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.github.plist; sourceTree = "<group>"; };
 		6F4102852260712F00F06A10 /* Free Ruler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Free Ruler.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F4102882260712F00F06A10 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6F41028D2260713100F06A10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -107,6 +131,7 @@
 		8F629823243003EA004F9099 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		8F629825243003F6004F9099 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/PreferencesController.xib; sourceTree = "<group>"; };
 		8F629828243003FF004F9099 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/PreferencesController.strings; sourceTree = "<group>"; };
+		AB053EE93E1DC9AF341A8D4F /* Free Ruler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "Free Ruler.app"; path = "Free Ruler.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B894A5002BBFE61A005A3B6F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		B894A5012BBFE61A005A3B6F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/PreferencesController.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -135,6 +160,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A8566957E136011B030A9C33 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				606AF9DF663B5C9F1444D88B /* Cocoa.framework in Frameworks */,
+				DA8EDBA823F8AC60DD774681 /* Sparkle in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -150,6 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				50A137022D03A00000137C0D /* XCTest.framework */,
+				637D287E638FC2DDD19B0FC8 /* OS X */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -160,6 +195,14 @@
 				50A147002D03C00000147C0D /* FreeRulerUITests.swift */,
 			);
 			path = FreeRulerUITests;
+			sourceTree = "<group>";
+		};
+		637D287E638FC2DDD19B0FC8 /* OS X */ = {
+			isa = PBXGroup;
+			children = (
+				0EAAF2519700045F2E236E44 /* Cocoa.framework */,
+			);
+			name = "OS X";
 			sourceTree = "<group>";
 		};
 		6F41027C2260712F00F06A10 = {
@@ -179,6 +222,7 @@
 				6F4102852260712F00F06A10 /* Free Ruler.app */,
 				50A137042D03A00000137C0D /* FreeRulerTests.xctest */,
 				50A147022D03C00000147C0D /* FreeRulerUITests.xctest */,
+				AB053EE93E1DC9AF341A8D4F /* Free Ruler.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -208,6 +252,7 @@
 				6F4102902260713100F06A10 /* Free_Ruler.entitlements */,
 				6F41028F2260713100F06A10 /* Info.plist */,
 				50C6D890228BDBAD0091F19E /* Images.xcassets */,
+				55ACACE1604925BB61E9D74C /* Info.github.plist */,
 			);
 			path = "Free Ruler";
 			sourceTree = "<group>";
@@ -270,6 +315,26 @@
 			productReference = 6F4102852260712F00F06A10 /* Free Ruler.app */;
 			productType = "com.apple.product-type.application";
 		};
+		FC9DC639BBDB0F3C10FD4344 /* Free Ruler GitHub */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8652141BA6BAF936C09F0274 /* Build configuration list for PBXNativeTarget "Free Ruler GitHub" */;
+			buildPhases = (
+				D1010F1FA9917D578EE3A20D /* Sources */,
+				A8566957E136011B030A9C33 /* Frameworks */,
+				8FF771F169F8566413E5222D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Free Ruler GitHub";
+			packageProductDependencies = (
+				7201D59F68C1B65518A4C10A /* Sparkle */,
+			);
+			productName = "Free Ruler";
+			productReference = AB053EE93E1DC9AF341A8D4F /* Free Ruler.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -307,6 +372,9 @@
 				ja,
 			);
 			mainGroup = 6F41027C2260712F00F06A10;
+			packageReferences = (
+				B220C5E385B022DDEF9D7608 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			productRefGroup = 6F4102862260712F00F06A10 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -314,6 +382,7 @@
 				6F4102842260712F00F06A10 /* Free Ruler */,
 				50A137082D03A00000137C0D /* FreeRulerTests */,
 				50A147082D03C00000147C0D /* FreeRulerUITests */,
+				FC9DC639BBDB0F3C10FD4344 /* Free Ruler GitHub */,
 			);
 		};
 /* End PBXProject section */
@@ -342,6 +411,18 @@
 				507FED44227FFF5300BD77DC /* PreferencesController.xib in Resources */,
 				50B146262D03B00000146C0D /* Localizable.xcstrings in Resources */,
 				6F41028E2260713100F06A10 /* MainMenu.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FF771F169F8566413E5222D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				378A15CD2C8708C2F8CB62E7 /* Images.xcassets in Resources */,
+				E9A35F3EE51A34DFC9D6097E /* FreeRuler.help in Resources */,
+				18769743B3FCD2594B0B8CF2 /* PreferencesController.xib in Resources */,
+				2ED12254704310C00A527F07 /* Localizable.xcstrings in Resources */,
+				2AFB3AE0D34FF01F00F671D4 /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -383,6 +464,28 @@
 				6F4102892260712F00F06A10 /* AppDelegate.swift in Sources */,
 				50D7BEED227D5C810008B95E /* RuleView.swift in Sources */,
 				50D7BEE9227D43270008B95E /* Ruler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1010F1FA9917D578EE3A20D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C47EEBC81CE13FEB9A2ADE5A /* Notifications.swift in Sources */,
+				2075141A6742AF52598D0314 /* Prefs.swift in Sources */,
+				2AAC34C01BE64CE025D5619D /* AppIconLayout.swift in Sources */,
+				012078ADCF85378A053BB9FA /* HotkeyBezel.swift in Sources */,
+				29E0CF116F5BCEA78DEA46BC /* RulerCursorController.swift in Sources */,
+				CD78B999536A29591C97FB80 /* MouseTickTimerPolicy.swift in Sources */,
+				B06EA4AC302536E25093D003 /* RulerTickLayout.swift in Sources */,
+				56B1A9290A8ADEA46E1D3129 /* HorizontalRule.swift in Sources */,
+				274FA3FF1BA7829144BBEB70 /* RulerWindow.swift in Sources */,
+				F73A5B5C974E514FD2663412 /* PreferencesController.swift in Sources */,
+				0C56237FE08F4155F0B63FFB /* RulerController.swift in Sources */,
+				5B52743D84FFD5EBF40B8558 /* VerticalRule.swift in Sources */,
+				23E2B80975F07733EB6CF5DB /* AppDelegate.swift in Sources */,
+				9A082BBC4A583513B0858C41 /* RuleView.swift in Sources */,
+				E6BC6663BAF0D11D7A9D2195 /* Ruler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -429,6 +532,64 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0BD2F2D59CC819CF9A964FD8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "Free Ruler/Free_Ruler.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 360;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "Free Ruler/Info.github.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@loader_path/../Frameworks",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 2.0.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pascal.freeruler;
+				PRODUCT_NAME = "Free Ruler";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SPARKLE_FEED_URL = "";
+				SPARKLE_PUBLIC_ED_KEY = "";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SPARKLE";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		461CCC60389C236CA6997EC6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "Free Ruler/Free_Ruler.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 360;
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				INFOPLIST_FILE = "Free Ruler/Info.github.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@loader_path/../Frameworks",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 2.0.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pascal.freeruler;
+				PRODUCT_NAME = "Free Ruler";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SPARKLE_FEED_URL = "";
+				SPARKLE_PUBLIC_ED_KEY = "";
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SPARKLE";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		50A1370B2D03A00000137C0D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -640,6 +801,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -666,6 +828,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -709,7 +872,35 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		8652141BA6BAF936C09F0274 /* Build configuration list for PBXNativeTarget "Free Ruler GitHub" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				461CCC60389C236CA6997EC6 /* Release */,
+				0BD2F2D59CC819CF9A964FD8 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		B220C5E385B022DDEF9D7608 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.9.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7201D59F68C1B65518A4C10A /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B220C5E385B022DDEF9D7608 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6F41027D2260712F00F06A10 /* Project object */;
 }

--- a/Free Ruler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Free Ruler.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "e721da7f9826abdffcb6185e886155efa2514bd6234475f1afa893e29eb258d6",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Free Ruler.xcodeproj/xcshareddata/xcschemes/Free Ruler GitHub.xcscheme
+++ b/Free Ruler.xcodeproj/xcshareddata/xcschemes/Free Ruler GitHub.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FC9DC639BBDB0F3C10FD4344"
+               BuildableName = "Free Ruler.app"
+               BlueprintName = "Free Ruler GitHub"
+               ReferencedContainer = "container:Free Ruler.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC9DC639BBDB0F3C10FD4344"
+            BuildableName = "Free Ruler.app"
+            BlueprintName = "Free Ruler GitHub"
+            ReferencedContainer = "container:Free Ruler.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC9DC639BBDB0F3C10FD4344"
+            BuildableName = "Free Ruler.app"
+            BlueprintName = "Free Ruler GitHub"
+            ReferencedContainer = "container:Free Ruler.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FC9DC639BBDB0F3C10FD4344"
+            BuildableName = "Free Ruler.app"
+            BlueprintName = "Free Ruler GitHub"
+            ReferencedContainer = "container:Free Ruler.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -133,7 +133,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard !appMenu.items.contains(where: { $0.action == #selector(checkForUpdates(_:)) }) else { return }
 
         let title = NSLocalizedString(
-            "Check for Updates...",
+            "Check for Updates…",
             comment: "Application menu item title for manually checking for software updates"
         )
         let item = NSMenuItem(

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -145,7 +145,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let insertionIndex = appMenu.items.firstIndex { $0.isSeparatorItem } ?? appMenu.items.count
         appMenu.insertItem(item, at: insertionIndex)
-        appMenu.insertItem(.separator(), at: insertionIndex + 1)
     }
 
     @objc private func checkForUpdates(_ sender: Any?) {

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -1,5 +1,8 @@
 import Cocoa
 import Carbon.HIToolbox
+#if SPARKLE
+import Sparkle
+#endif
 
 let env = ProcessInfo.processInfo.environment
 let APP_ICON_HELPER = env["APP_ICON_HELPER"] != nil
@@ -77,6 +80,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var preferencesController: PreferencesController? = nil
     private let hotkeyBezel = HotkeyBezel()
+#if SPARKLE
+    private var updaterController: SPUStandardUpdaterController?
+#endif
 
     // MARK: - Lifecycle
 
@@ -88,6 +94,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         subscribeToPrefs()
         updateDisplay()
+#if SPARKLE
+        configureUpdater()
+#endif
 
         if APP_ICON_HELPER {
             let helper = AppIconLayout()
@@ -97,6 +106,52 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
     }
+
+#if SPARKLE
+    private func configureUpdater() {
+        guard !APP_ICON_HELPER else { return }
+        guard hasSparkleConfiguration else { return }
+
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        installCheckForUpdatesMenuItem()
+    }
+
+    private var hasSparkleConfiguration: Bool {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let feedURL = info["SUFeedURL"] as? String
+        let publicKey = info["SUPublicEDKey"] as? String
+
+        return feedURL?.isEmpty == false && publicKey?.isEmpty == false
+    }
+
+    private func installCheckForUpdatesMenuItem() {
+        guard let appMenu = NSApp.mainMenu?.item(at: 0)?.submenu else { return }
+        guard !appMenu.items.contains(where: { $0.action == #selector(checkForUpdates(_:)) }) else { return }
+
+        let title = NSLocalizedString(
+            "Check for Updates...",
+            comment: "Application menu item title for manually checking for software updates"
+        )
+        let item = NSMenuItem(
+            title: title,
+            action: #selector(checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+
+        let insertionIndex = appMenu.items.firstIndex { $0.isSeparatorItem } ?? appMenu.items.count
+        appMenu.insertItem(item, at: insertionIndex)
+        appMenu.insertItem(.separator(), at: insertionIndex + 1)
+    }
+
+    @objc private func checkForUpdates(_ sender: Any?) {
+        updaterController?.checkForUpdates(sender)
+    }
+#endif
 
     func subscribeToPrefs() {
         observers = [

--- a/Free Ruler/Info.github.plist
+++ b/Free Ruler/Info.github.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleHelpBookFolder</key>
+	<string>FreeRuler.help</string>
+	<key>CFBundleHelpBookName</key>
+	<string>com.pascal.freeruler.help</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string></string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<key>SUFeedURL</key>
+	<string>$(SPARKLE_FEED_URL)</string>
+	<key>SUPublicEDKey</key>
+	<string>$(SPARKLE_PUBLIC_ED_KEY)</string>
+</dict>
+</plist>

--- a/Free Ruler/Localizable.xcstrings
+++ b/Free Ruler/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Check for Updates..." : {
+      "comment" : "Application menu item title for manually checking for software updates"
+    },
     "Hide Horizontal Ruler" : {
       "comment" : "Menu item title to hide the horizontal ruler",
       "extractionState" : "manual",

--- a/Free Ruler/Localizable.xcstrings
+++ b/Free Ruler/Localizable.xcstrings
@@ -1,38 +1,38 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Check for Updates..." : {
+    "Check for Updates…" : {
       "comment" : "Application menu item title for manually checking for software updates",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nach Updates suchen..."
+            "value" : "Nach Updates suchen…"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Check for Updates..."
+            "value" : "Check for Updates…"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tarkista päivitykset..."
+            "value" : "Tarkista päivitykset…"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "アップデートを確認..."
+            "value" : "アップデートを確認…"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检查更新..."
+            "value" : "检查更新…"
           }
         }
       }

--- a/Free Ruler/Localizable.xcstrings
+++ b/Free Ruler/Localizable.xcstrings
@@ -8,7 +8,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nach Updates suchen ..."
+            "value" : "Nach Updates suchen..."
           }
         },
         "en" : {

--- a/Free Ruler/Localizable.xcstrings
+++ b/Free Ruler/Localizable.xcstrings
@@ -2,7 +2,40 @@
   "sourceLanguage" : "en",
   "strings" : {
     "Check for Updates..." : {
-      "comment" : "Application menu item title for manually checking for software updates"
+      "comment" : "Application menu item title for manually checking for software updates",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nach Updates suchen ..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check for Updates..."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarkista päivitykset..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを確認..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新..."
+          }
+        }
+      }
     },
     "Hide Horizontal Ruler" : {
       "comment" : "Menu item title to hide the horizontal ruler",

--- a/HOW-TO-RELEASE.md
+++ b/HOW-TO-RELEASE.md
@@ -33,7 +33,7 @@ Assuming you have the prerequisites listed below, follow these steps from a term
 3. Build, notarize, zip, and create a draft GitHub Release.
 
    ```sh
-   NOTARYTOOL_PROFILE=FreeRulerNotary npm run release:github
+   npm run release:github
    ```
 
 4. Publish the draft release.
@@ -63,7 +63,7 @@ public release.
 2. Test the full path with a temporary draft release.
 
    ```sh
-   RELEASE_TAG=vX.Y.Z-test.1 NOTARYTOOL_PROFILE=FreeRulerNotary npm run release:github
+   RELEASE_TAG=vX.Y.Z-test.1 npm run release:github
    ```
 
    Replace `X.Y.Z` with the version currently in `package.json`. This creates a
@@ -93,6 +93,8 @@ The GitHub release command expects:
 - Xcode signing working for the Free Ruler app target.
 - A Developer ID Application certificate installed.
 - Notary credentials saved in Keychain.
+- Local release environment configured. See **Release environment** below.
+- Sparkle signing configured. See **Sparkle updates** below.
 
 The documented commands assume the notary profile is named `FreeRulerNotary`.
 Create that profile once with:
@@ -101,11 +103,41 @@ Create that profile once with:
 xcrun notarytool store-credentials "FreeRulerNotary"
 ```
 
-If Xcode needs to create or update signing assets during archive/export, add
+Create a local `.env` file with release settings:
+
+```sh
+cat > .env <<'EOF'
+NOTARYTOOL_PROFILE=FreeRulerNotary
+SPARKLE_PUBLIC_ED_KEY=...
+EOF
+```
+
+If Xcode needs to create or update signing assets during archive/export, set
 `ALLOW_PROVISIONING_UPDATES=1`:
 
 ```sh
-ALLOW_PROVISIONING_UPDATES=1 NOTARYTOOL_PROFILE=FreeRulerNotary npm run release:github
+ALLOW_PROVISIONING_UPDATES=1 npm run release:github
+```
+
+</details>
+
+<details>
+<summary>Release environment</summary>
+
+Release scripts read local settings from `.env` at the repository root. That
+file is ignored by git. Values already set in the shell override `.env` values.
+
+Example:
+
+```sh
+NOTARYTOOL_PROFILE=FreeRulerNotary
+SPARKLE_PUBLIC_ED_KEY=...
+```
+
+To use a different file, set `RELEASE_ENV_FILE`:
+
+```sh
+RELEASE_ENV_FILE=~/FreeRuler.release.env npm run release:github
 ```
 
 </details>
@@ -121,6 +153,7 @@ npm run release:github:archive
 npm run release:github:export
 npm run release:github:notarize
 npm run release:github:zip
+npm run release:github:appcast
 npm run release:github:publish
 ```
 
@@ -167,6 +200,35 @@ Set an exact version and Xcode build number:
 
 ```sh
 npm run release:version -- X.Y.Z 303
+```
+
+</details>
+
+<details>
+<summary>Sparkle updates</summary>
+
+GitHub release builds enable Sparkle updates. The App Store target does not
+include Sparkle.
+
+Sparkle expects:
+
+- Sparkle's `sign_update` tool on `PATH`, or `SPARKLE_SIGN_UPDATE` set to its
+  full path.
+- `SPARKLE_PUBLIC_ED_KEY` set to the public EdDSA update key. The matching
+  private key must be available to Sparkle's signing tool when generating the
+  appcast. `SPARKLE_PUBLIC_ED_KEY` can live in `.env`.
+
+The release command writes the appcast to:
+
+```sh
+build/release/appcast.xml
+```
+
+The draft GitHub Release uploads both the zip and `appcast.xml`. Published
+GitHub releases serve the update feed at:
+
+```text
+https://github.com/pascalpp/FreeRuler/releases/latest/download/appcast.xml
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "release:github:export": "scripts/release/export-github-release.sh",
     "release:github:notarize": "scripts/release/notarize-github-release.sh",
     "release:github:zip": "scripts/release/zip-github-release.sh",
+    "release:github:appcast": "scripts/release/generate-appcast.sh",
     "release:github:publish": "scripts/release/publish-github-release.sh",
     "release:github": "scripts/release/github-release.sh",
     "github:release:dryrun": "RELEASE_DRY_RUN=1 RELEASE_SKIP_NOTARIZE=1 RELEASE_OVERWRITE=1 scripts/release/github-release.sh"

--- a/scripts/release/archive-github-release.sh
+++ b/scripts/release/archive-github-release.sh
@@ -7,15 +7,23 @@ source "$(dirname "$0")/common.sh"
 run_from_root
 require_tool xcodebuild
 
+if [[ -z "${SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
+  echo "SPARKLE_PUBLIC_ED_KEY is required for GitHub release archives." >&2
+  echo "Create one with Sparkle's generate_keys tool, then export the public key before releasing." >&2
+  exit 1
+fi
+
 mkdir -p "$RELEASE_DIR"
 rm -rf "$ARCHIVE_PATH"
 
 xcodebuild archive \
   -project "$PROJECT_PATH" \
-  -scheme "$SCHEME_NAME" \
+  -scheme "$GITHUB_SCHEME_NAME" \
   -configuration "$CONFIGURATION" \
   -destination "generic/platform=macOS" \
   -archivePath "$ARCHIVE_PATH" \
+  SPARKLE_FEED_URL="$SPARKLE_FEED_URL" \
+  SPARKLE_PUBLIC_ED_KEY="$SPARKLE_PUBLIC_ED_KEY" \
   $(xcodebuild_provisioning_flags)
 
 echo "Created archive: $ARCHIVE_PATH"

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -3,8 +3,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RELEASE_ENV_FILE="${RELEASE_ENV_FILE:-$ROOT_DIR/.env}"
 PROJECT_PATH="$ROOT_DIR/Free Ruler.xcodeproj"
 SCHEME_NAME="Free Ruler"
+GITHUB_SCHEME_NAME="Free Ruler GitHub"
 CONFIGURATION="Release"
 APP_NAME="Free Ruler"
 APP_BUNDLE_NAME="$APP_NAME.app"
@@ -12,6 +14,47 @@ RELEASE_DIR="$ROOT_DIR/build/release"
 ARCHIVE_PATH="$RELEASE_DIR/$APP_NAME.xcarchive"
 EXPORT_DIR="$RELEASE_DIR/export"
 EXPORT_OPTIONS_PLIST="$ROOT_DIR/scripts/release/ExportOptions.github.plist"
+APPCAST_PATH="$RELEASE_DIR/appcast.xml"
+SPARKLE_FEED_URL="https://github.com/pascalpp/FreeRuler/releases/latest/download/appcast.xml"
+
+load_release_env() {
+  [[ -f "$RELEASE_ENV_FILE" ]] || return 0
+
+  local line key value
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+
+    [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+
+    if [[ "$line" == export[[:space:]]* ]]; then
+      line="${line#export}"
+      line="${line#"${line%%[![:space:]]*}"}"
+    fi
+
+    [[ "$line" == *=* ]] || continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    key="${key%"${key##*[![:space:]]}"}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    [[ -z "${!key+x}" ]] || continue
+
+    if [[ "${#value}" -ge 2 ]]; then
+      if [[ "${value:0:1}" == '"' && "${value: -1}" == '"' ]]; then
+        value="${value:1:${#value}-2}"
+      elif [[ "${value:0:1}" == "'" && "${value: -1}" == "'" ]]; then
+        value="${value:1:${#value}-2}"
+      fi
+    fi
+
+    export "$key=$value"
+  done <"$RELEASE_ENV_FILE"
+}
+
+load_release_env
 
 version() {
   node -p "require('./package.json').version"
@@ -27,6 +70,14 @@ release_tag() {
 
 release_zip_path() {
   printf "%s/free-ruler-%s.zip" "$RELEASE_DIR" "$(version)"
+}
+
+release_zip_name() {
+  printf "free-ruler-%s.zip" "$(version)"
+}
+
+release_zip_url() {
+  printf "https://github.com/pascalpp/FreeRuler/releases/download/%s/%s" "$(release_tag)" "$(release_zip_name)"
 }
 
 exported_app_path() {

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -15,7 +15,6 @@ ARCHIVE_PATH="$RELEASE_DIR/$APP_NAME.xcarchive"
 EXPORT_DIR="$RELEASE_DIR/export"
 EXPORT_OPTIONS_PLIST="$ROOT_DIR/scripts/release/ExportOptions.github.plist"
 APPCAST_PATH="$RELEASE_DIR/appcast.xml"
-SPARKLE_FEED_URL="https://github.com/pascalpp/FreeRuler/releases/latest/download/appcast.xml"
 
 load_release_env() {
   [[ -f "$RELEASE_ENV_FILE" ]] || return 0
@@ -55,6 +54,8 @@ load_release_env() {
 }
 
 load_release_env
+
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://github.com/pascalpp/FreeRuler/releases/latest/download/appcast.xml}"
 
 version() {
   node -p "require('./package.json').version"
@@ -104,8 +105,9 @@ ensure_clean_worktree() {
 
 build_setting() {
   local setting="$1"
+  local scheme="${2:-$SCHEME_NAME}"
   xcodebuild -project "$PROJECT_PATH" \
-    -scheme "$SCHEME_NAME" \
+    -scheme "$scheme" \
     -configuration "$CONFIGURATION" \
     -showBuildSettings 2>/dev/null \
     | awk -F ' = ' -v key="$setting" '$1 ~ key "$" { print $2; exit }'

--- a/scripts/release/generate-appcast.sh
+++ b/scripts/release/generate-appcast.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+run_from_root
+require_tool node
+
+sign_update_tool="${SPARKLE_SIGN_UPDATE:-sign_update}"
+require_tool "$sign_update_tool"
+
+zip_path="$(release_zip_path)"
+zip_url="$(release_zip_url)"
+version="$(version)"
+tag="$(release_tag)"
+release_notes_url="https://github.com/pascalpp/FreeRuler/releases/tag/$tag"
+
+if [[ ! -f "$zip_path" ]]; then
+  echo "Release zip not found: $zip_path" >&2
+  echo "Run npm run release:github:zip first." >&2
+  exit 1
+fi
+
+signature_output="$("$sign_update_tool" "$zip_path")"
+
+if [[ "$signature_output" != sparkle:edSignature* ]]; then
+  echo "Unexpected sign_update output:" >&2
+  echo "$signature_output" >&2
+  exit 1
+fi
+
+mkdir -p "$RELEASE_DIR"
+
+node - "$APPCAST_PATH" "$version" "$tag" "$zip_url" "$release_notes_url" "$signature_output" <<'NODE'
+const fs = require('fs');
+
+const [
+  appcastPath,
+  version,
+  tag,
+  zipURL,
+  releaseNotesURL,
+  signatureAttributes,
+] = process.argv.slice(2);
+
+function escapeXML(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const pubDate = new Date().toUTCString();
+const appcast = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Free Ruler Updates</title>
+    <link>https://github.com/pascalpp/FreeRuler/releases</link>
+    <description>Free Ruler release updates</description>
+    <item>
+      <title>${escapeXML(tag)}</title>
+      <sparkle:releaseNotesLink>${escapeXML(releaseNotesURL)}</sparkle:releaseNotesLink>
+      <pubDate>${escapeXML(pubDate)}</pubDate>
+      <enclosure
+        url="${escapeXML(zipURL)}"
+        sparkle:version="${escapeXML(version)}"
+        sparkle:shortVersionString="${escapeXML(version)}"
+        ${signatureAttributes}
+        type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>
+`;
+
+fs.writeFileSync(appcastPath, appcast);
+NODE
+
+echo "Created appcast: $APPCAST_PATH"

--- a/scripts/release/generate-appcast.sh
+++ b/scripts/release/generate-appcast.sh
@@ -6,6 +6,7 @@ source "$(dirname "$0")/common.sh"
 
 run_from_root
 require_tool node
+require_tool xcodebuild
 
 sign_update_tool="${SPARKLE_SIGN_UPDATE:-sign_update}"
 require_tool "$sign_update_tool"
@@ -13,7 +14,7 @@ require_tool "$sign_update_tool"
 zip_path="$(release_zip_path)"
 zip_url="$(release_zip_url)"
 version="$(version)"
-build_version="$(build_setting CURRENT_PROJECT_VERSION)"
+build_version="$(build_setting CURRENT_PROJECT_VERSION "$GITHUB_SCHEME_NAME")"
 tag="$(release_tag)"
 release_notes_url="https://github.com/pascalpp/FreeRuler/releases/tag/$tag"
 

--- a/scripts/release/generate-appcast.sh
+++ b/scripts/release/generate-appcast.sh
@@ -13,12 +13,18 @@ require_tool "$sign_update_tool"
 zip_path="$(release_zip_path)"
 zip_url="$(release_zip_url)"
 version="$(version)"
+build_version="$(build_setting CURRENT_PROJECT_VERSION)"
 tag="$(release_tag)"
 release_notes_url="https://github.com/pascalpp/FreeRuler/releases/tag/$tag"
 
 if [[ ! -f "$zip_path" ]]; then
   echo "Release zip not found: $zip_path" >&2
   echo "Run npm run release:github:zip first." >&2
+  exit 1
+fi
+
+if [[ -z "$build_version" ]]; then
+  echo "Unable to determine Xcode CURRENT_PROJECT_VERSION." >&2
   exit 1
 fi
 
@@ -32,12 +38,13 @@ fi
 
 mkdir -p "$RELEASE_DIR"
 
-node - "$APPCAST_PATH" "$version" "$tag" "$zip_url" "$release_notes_url" "$signature_output" <<'NODE'
+node - "$APPCAST_PATH" "$version" "$build_version" "$tag" "$zip_url" "$release_notes_url" "$signature_output" <<'NODE'
 const fs = require('fs');
 
 const [
   appcastPath,
   version,
+  buildVersion,
   tag,
   zipURL,
   releaseNotesURL,
@@ -66,7 +73,7 @@ const appcast = `<?xml version="1.0" encoding="utf-8"?>
       <pubDate>${escapeXML(pubDate)}</pubDate>
       <enclosure
         url="${escapeXML(zipURL)}"
-        sparkle:version="${escapeXML(version)}"
+        sparkle:version="${escapeXML(buildVersion)}"
         sparkle:shortVersionString="${escapeXML(version)}"
         ${signatureAttributes}
         type="application/octet-stream" />

--- a/scripts/release/github-release.sh
+++ b/scripts/release/github-release.sh
@@ -15,4 +15,5 @@ else
 fi
 
 "$script_dir/zip-github-release.sh"
+"$script_dir/generate-appcast.sh"
 "$script_dir/publish-github-release.sh"

--- a/scripts/release/publish-github-release.sh
+++ b/scripts/release/publish-github-release.sh
@@ -10,6 +10,7 @@ require_tool node
 
 tag="$(release_tag)"
 zip_path="$(release_zip_path)"
+appcast_path="$APPCAST_PATH"
 
 if [[ ! -f "$zip_path" ]]; then
   echo "Release zip not found: $zip_path" >&2
@@ -17,8 +18,14 @@ if [[ ! -f "$zip_path" ]]; then
   exit 1
 fi
 
+if [[ ! -f "$appcast_path" ]]; then
+  echo "Appcast not found: $appcast_path" >&2
+  echo "Run npm run release:github:appcast first." >&2
+  exit 1
+fi
+
 if is_dry_run; then
-  echo "Dry run: would create or update draft GitHub release $tag with $zip_path."
+  echo "Dry run: would create or update draft GitHub release $tag with $zip_path and $appcast_path."
   exit 0
 fi
 
@@ -32,9 +39,9 @@ fi
 git push origin "$tag"
 
 if gh release view "$tag" >/dev/null 2>&1; then
-  gh release upload "$tag" "$zip_path" --clobber
+  gh release upload "$tag" "$zip_path" "$appcast_path" --clobber
 else
-  gh release create "$tag" "$zip_path" --title "$tag" --notes "$tag" --draft
+  gh release create "$tag" "$zip_path" "$appcast_path" --title "$tag" --notes "$tag" --draft
 fi
 
 echo "Created or updated draft GitHub release: $tag"


### PR DESCRIPTION
## Summary

- Add a Sparkle-enabled GitHub release target and shared scheme while keeping the existing app target free of Sparkle for App Store builds.
- Wire Sparkle startup and a Check for Updates menu item behind the `SPARKLE` compile condition.
- Extend the GitHub release pipeline to read local `.env` settings, generate a signed Sparkle appcast, and upload it alongside the release zip.
- Document first-time `.env`, Sparkle signing, and release environment setup.

Closes #163

## Validation

- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" -configuration Debug -destination 'platform=macOS' -derivedDataPath build/verify-main CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler GitHub" -configuration Debug -destination 'platform=macOS' -derivedDataPath build/verify-github CODE_SIGNING_ALLOWED=NO SPARKLE_FEED_URL='https://github.com/pascalpp/FreeRuler/releases/latest/download/appcast.xml' SPARKLE_PUBLIC_ED_KEY='test-key' build`
- `npm run github:release:dryrun`
- `bash -n scripts/release/common.sh scripts/release/archive-github-release.sh scripts/release/generate-appcast.sh scripts/release/github-release.sh scripts/release/publish-github-release.sh`
- `git diff --check`