### PR TITLE
[codex] Fix Sparkle sandbox update entitlements

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		53AF6A4225A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		53AF6A4325A456E30076AAB7 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/PreferencesController.strings; sourceTree = "<group>"; };
 		55ACACE1604925BB61E9D74C /* Info.github.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.github.plist; sourceTree = "<group>"; };
+		55ACACE2604925BB61E9D74C /* Free_Ruler.github.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Free_Ruler.github.entitlements; sourceTree = "<group>"; };
 		6F4102852260712F00F06A10 /* Free Ruler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Free Ruler.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F4102882260712F00F06A10 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6F41028D2260713100F06A10 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -246,6 +247,7 @@
 				507FED42227FFF5300BD77DC /* PreferencesController.xib */,
 				50CCB205227FCD26004645C5 /* AppIconLayout.swift */,
 				6F4102902260713100F06A10 /* Free_Ruler.entitlements */,
+				55ACACE2604925BB61E9D74C /* Free_Ruler.github.entitlements */,
 				6F41028F2260713100F06A10 /* Info.plist */,
 				50C6D890228BDBAD0091F19E /* Images.xcassets */,
 				55ACACE1604925BB61E9D74C /* Info.github.plist */,
@@ -532,7 +534,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = "Free Ruler/Free_Ruler.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Free Ruler/Free_Ruler.github.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -561,7 +563,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = "Free Ruler/Free_Ruler.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Free Ruler/Free_Ruler.github.entitlements";
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/Free Ruler/Free_Ruler.github.entitlements
+++ b/Free Ruler/Free_Ruler.github.entitlements
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
+		<string>$(PRODUCT_BUNDLE_IDENTIFIER)-spki</string>
+	</array>
+</dict>
+</plist>

--- a/Free Ruler/Info.github.plist
+++ b/Free Ruler/Info.github.plist
@@ -34,6 +34,8 @@
 	<string>NSApplication</string>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>$(SPARKLE_FEED_URL)</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
## Summary

Adds the missing sandbox integration pieces Sparkle needs in the GitHub release build, scoped to a GitHub-only entitlements file:

- enables Sparkle's installer launcher service via `SUEnableInstallerLauncherService`
- adds `Free_Ruler.github.entitlements` for the GitHub/Sparkle target
- enables outgoing network access for the GitHub release app
- allows Sparkle's installer status/communication mach lookups via `com.pascal.freeruler-spks` and `com.pascal.freeruler-spki`
- leaves the App Store/main target on the original shared `Free_Ruler.entitlements`

## Root Cause

The published appcast and release zip are reachable and the Sparkle EdDSA signature matches the live zip, but the released app is sandboxed without `com.apple.security.network.client`. That leaves Sparkle unable to retrieve update information from the app process. The app also lacked the installer launcher setup Sparkle documents for sandboxed apps.

## Validation

- `plutil -lint Free Ruler/Free_Ruler.entitlements Free Ruler/Free_Ruler.github.entitlements Free Ruler/Info.github.plist`
- Confirmed build settings:
  - `Free Ruler GitHub` uses `Free Ruler/Free_Ruler.github.entitlements`
  - `Free Ruler` uses `Free Ruler/Free_Ruler.entitlements`
- Built `Free Ruler GitHub` Release locally with Developer ID signing overrides
- Verified the built GitHub app contains:
  - `com.apple.security.network.client = true`
  - `com.apple.security.temporary-exception.mach-lookup.global-name = com.pascal.freeruler-spks, com.pascal.freeruler-spki`
  - `SUEnableInstallerLauncherService = true`
- `codesign --verify --deep --strict --verbose=4 build/verify-sparkle-entitlement-split/Build/Products/Release/Free Ruler.app`