### PR TITLE
[codex] Add Spanish localization

### DIFF
--- a/Free Ruler.xcodeproj/project.pbxproj
+++ b/Free Ruler.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		AB053EE93E1DC9AF341A8D4F /* Free Ruler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = "Free Ruler.app"; path = "Free Ruler.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B894A5002BBFE61A005A3B6F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		B894A5012BBFE61A005A3B6F /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/PreferencesController.strings; sourceTree = "<group>"; };
+		D9DBE8A12C791B1600A42589 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		D9DBE8A22C791B1600A42589 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/PreferencesController.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -372,6 +374,7 @@
 				fi,
 				"zh-Hans",
 				ja,
+				es,
 			);
 			mainGroup = 6F41027C2260712F00F06A10;
 			packageReferences = (
@@ -517,6 +520,7 @@
 				53AF6A4325A456E30076AAB7 /* fi */,
 				6F8CAA3A29CC8F7D00C4ED57 /* zh-Hans */,
 				B894A5012BBFE61A005A3B6F /* ja */,
+				D9DBE8A22C791B1600A42589 /* es */,
 			);
 			name = PreferencesController.xib;
 			sourceTree = "<group>";
@@ -529,6 +533,7 @@
 				53AF6A4225A456E30076AAB7 /* fi */,
 				6F8CAA3929CC8F7D00C4ED57 /* zh-Hans */,
 				B894A5002BBFE61A005A3B6F /* ja */,
+				D9DBE8A12C791B1600A42589 /* es */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";

--- a/Free Ruler/Localizable.xcstrings
+++ b/Free Ruler/Localizable.xcstrings
@@ -17,6 +17,12 @@
             "value" : "Check for Updates…"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar actualizaciones…"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51,6 +57,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hide Horizontal Ruler"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar regla horizontal"
           }
         },
         "fi" : {
@@ -89,6 +101,12 @@
             "value" : "Hide Vertical Ruler"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocultar regla vertical"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -123,6 +141,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Horizontal Ruler"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regla horizontal"
           }
         },
         "fi" : {
@@ -161,6 +185,12 @@
             "value" : "Rulers floated"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas flotantes"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -195,6 +225,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rulers grouped"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas agrupadas"
           }
         },
         "fi" : {
@@ -233,6 +269,12 @@
             "value" : "Rulers unfloated"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas no flotantes"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -267,6 +309,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rulers ungrouped"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reglas desagrupadas"
           }
         },
         "fi" : {
@@ -305,6 +353,12 @@
             "value" : "Shadow disabled"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombra desactivada"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -339,6 +393,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Shadow enabled"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombra activada"
           }
         },
         "fi" : {
@@ -377,6 +437,12 @@
             "value" : "Units: %@"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unidades: %@"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -411,6 +477,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Show All Rulers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar todas las reglas"
           }
         },
         "fi" : {
@@ -449,6 +521,12 @@
             "value" : "Show Horizontal Ruler"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar regla horizontal"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -485,6 +563,12 @@
             "value" : "Show Vertical Ruler"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar regla vertical"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -516,6 +600,12 @@
           }
         },
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "in"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "in"
@@ -557,6 +647,12 @@
             "value" : "mm"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "mm"
+          }
+        },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
@@ -588,6 +684,12 @@
           }
         },
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "px"
+          }
+        },
+        "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "px"
@@ -627,6 +729,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vertical Ruler"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regla vertical"
           }
         },
         "fi" : {

--- a/Free Ruler/es.lproj/MainMenu.strings
+++ b/Free Ruler/es.lproj/MainMenu.strings
@@ -1,0 +1,138 @@
+
+/* Class = "NSMenuItem"; title = "Free Ruler"; ObjectID = "1Xt-HY-uBw"; */
+"1Xt-HY-uBw.title" = "Free Ruler";
+
+/* Class = "NSMenuItem"; title = "Cycle Units"; ObjectID = "2nm-aL-kZd"; */
+"2nm-aL-kZd.title" = "Cambiar unidades";
+
+/* Class = "NSMenuItem"; title = "Quit Free Ruler"; ObjectID = "4sb-4s-VLi"; */
+"4sb-4s-VLi.title" = "Salir de Free Ruler";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
+"5QF-Oa-p0T.title" = "Edición";
+
+/* Class = "NSMenuItem"; title = "About Free Ruler"; ObjectID = "5kV-Vb-QxS"; */
+"5kV-Vb-QxS.title" = "Acerca de Free Ruler";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "6dh-zS-Vam"; */
+"6dh-zS-Vam.title" = "Rehacer";
+
+/* Class = "NSMenuItem"; title = "Reset Ruler Positions"; ObjectID = "6ph-5N-O9R"; */
+"6ph-5N-O9R.title" = "Restablecer posiciones de las reglas";
+
+/* Class = "NSMenuItem"; title = "Group Rulers"; ObjectID = "7Ga-Fb-LLc"; */
+"7Ga-Fb-LLc.title" = "Agrupar reglas";
+
+/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "Menú principal";
+
+/* Class = "NSMenuItem"; title = "Millimeters"; ObjectID = "B6Y-Hi-AkN"; */
+"B6Y-Hi-AkN.title" = "Milímetros";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "Preferencias…";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
+"DVo-aG-piG.title" = "Cerrar";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+"F2S-fz-NVQ.title" = "Ayuda";
+
+/* Class = "NSMenuItem"; title = "Free Ruler Help"; ObjectID = "FKE-Sm-Kum"; */
+"FKE-Sm-Kum.title" = "Ayuda de Free Ruler";
+
+/* Class = "NSMenuItem"; title = "Float Rulers"; ObjectID = "GDK-AC-uC8"; */
+"GDK-AC-uC8.title" = "Reglas flotantes";
+
+/* Class = "NSMenuItem"; title = "Options"; ObjectID = "H8h-7b-M4v"; */
+"H8h-7b-M4v.title" = "Opciones";
+
+/* Class = "NSMenu"; title = "Options"; ObjectID = "HyV-fh-RgO"; */
+"HyV-fh-RgO.title" = "Opciones";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+"Kd2-mp-pUS.title" = "Mostrar todo";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "LE2-aR-0XJ"; */
+"LE2-aR-0XJ.title" = "Traer todo al frente";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+"NMo-om-nkz.title" = "Servicios";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "OY7-WF-poV"; */
+"OY7-WF-poV.title" = "Minimizar";
+
+/* Class = "NSMenuItem"; title = "Close"; ObjectID = "n0M-rw-v5l"; */
+"n0M-rw-v5l.title" = "Cerrar";
+
+/* Class = "NSMenuItem"; title = "Hide Free Ruler"; ObjectID = "Olw-nP-bQN"; */
+"Olw-nP-bQN.title" = "Ocultar Free Ruler";
+
+/* Class = "NSMenuItem"; title = "Zoom"; ObjectID = "R4o-n2-Eq4"; */
+"R4o-n2-Eq4.title" = "Zoom";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "Ruw-6m-B2m"; */
+"Ruw-6m-B2m.title" = "Seleccionar todo";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "Td7-aD-5lo"; */
+"Td7-aD-5lo.title" = "Ventana";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+"Vdr-fp-XzO.title" = "Ocultar otras";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "W48-6f-4Dl"; */
+"W48-6f-4Dl.title" = "Edición";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "WeT-3V-zwk"; */
+"WeT-3V-zwk.title" = "Pegar con el mismo estilo";
+
+/* Class = "NSMenuItem"; title = "Show Ruler Shadow"; ObjectID = "a8D-hN-A59"; */
+"a8D-hN-A59.title" = "Mostrar sombra de la regla";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "aUF-d1-5bR"; */
+"aUF-d1-5bR.title" = "Ventana";
+
+/* Class = "NSMenu"; title = "Ruler"; ObjectID = "bib-Uj-vzu"; */
+"bib-Uj-vzu.title" = "Regla";
+
+/* Class = "NSMenuItem"; title = "Ruler"; ObjectID = "dMs-cI-mzQ"; */
+"dMs-cI-mzQ.title" = "Regla";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "dRJ-4n-Yzg"; */
+"dRJ-4n-Yzg.title" = "Deshacer";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "gVA-U4-sdL"; */
+"gVA-U4-sdL.title" = "Pegar";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+"hz9-B4-Xy5.title" = "Servicios";
+
+/* Class = "NSMenuItem"; title = "Unit"; ObjectID = "iDP-2z-irv"; */
+"iDP-2z-irv.title" = "Unidad";
+
+/* Class = "NSMenuItem"; title = "Align Rulers at Mouse Location"; ObjectID = "iKV-uW-hwy"; */
+"iKV-uW-hwy.title" = "Alinear reglas con el ratón";
+
+/* Class = "NSMenuItem"; title = "Inches"; ObjectID = "lt1-Hj-2TR"; */
+"lt1-Hj-2TR.title" = "Pulgadas";
+
+/* Class = "NSMenuItem"; title = "Pixels"; ObjectID = "pYR-Ba-kKi"; */
+"pYR-Ba-kKi.title" = "Píxeles";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "pa3-QI-u2k"; */
+"pa3-QI-u2k.title" = "Eliminar";
+
+/* Class = "NSMenu"; title = "Free Ruler"; ObjectID = "uQy-DD-JDr"; */
+"uQy-DD-JDr.title" = "Free Ruler";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "uRl-iY-unG"; */
+"uRl-iY-unG.title" = "Cortar";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+"wpr-3q-Mcd.title" = "Ayuda";
+
+/* Class = "NSMenu"; title = "Unit"; ObjectID = "z2p-dA-zcS"; */
+"z2p-dA-zcS.title" = "Unidad";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "x3v-GG-iWU"; */
+"x3v-GG-iWU.title" = "Copiar";

--- a/Free Ruler/es.lproj/PreferencesController.strings
+++ b/Free Ruler/es.lproj/PreferencesController.strings
@@ -1,0 +1,27 @@
+
+/* Class = "NSButtonCell"; title = "Reset Ruler Positions"; ObjectID = "10f-9L-qca"; */
+"10f-9L-qca.title" = "Restablecer posiciones de las reglas";
+
+/* Class = "NSTextFieldCell"; title = "Foreground Opacity"; ObjectID = "BgV-9N-IVn"; */
+"BgV-9N-IVn.title" = "Opacidad del primer plano";
+
+/* Class = "NSWindow"; title = "Free Ruler Preferences"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Preferencias de Free Ruler";
+
+/* Class = "NSButtonCell"; title = "Group rulers"; ObjectID = "N2Y-8B-L9c"; */
+"N2Y-8B-L9c.title" = "Agrupar reglas";
+
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "VXi-Ch-Jf5"; */
+"VXi-Ch-Jf5.title" = "Etiqueta";
+
+/* Class = "NSTextFieldCell"; title = "Label"; ObjectID = "Vqd-CI-vmd"; */
+"Vqd-CI-vmd.title" = "Etiqueta";
+
+/* Class = "NSTextFieldCell"; title = "Background Opacity"; ObjectID = "cRb-8z-VZj"; */
+"cRb-8z-VZj.title" = "Opacidad del fondo";
+
+/* Class = "NSButtonCell"; title = "Show ruler shadow"; ObjectID = "l53-85-hoA"; */
+"l53-85-hoA.title" = "Mostrar sombra de la regla";
+
+/* Class = "NSButtonCell"; title = "Float rulers above other applications"; ObjectID = "yPM-Cw-Qsi"; */
+"yPM-Cw-Qsi.title" = "Reglas flotantes sobre otras aplicaciones";


### PR DESCRIPTION
## Summary

- resurrects the usable Spanish localization work from #127
- adds Spanish XIB strings for the main menu and preferences window
- adds Spanish entries for the newer `Localizable.xcstrings` runtime strings, including ruler visibility titles, hotkey bezel messages, unit labels, and update checking

## Notes

The closed PR also changed the Xcode `DEVELOPMENT_TEAM`; this PR intentionally leaves signing settings untouched.

## Validation

- `plutil -lint Free Ruler/es.lproj/MainMenu.strings Free Ruler/es.lproj/PreferencesController.strings`
- `node -e 'JSON.parse(require("fs").readFileSync("Free Ruler/Localizable.xcstrings","utf8")); console.log("Localizable.xcstrings JSON OK")'`
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" build`