### PR TITLE
[codex] Hide mouse ticks while dragging rulers

### DIFF
--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -15,6 +15,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     var keyListener: Any?
     private var mouseTickResumeTimer: Timer?
     private let mouseTickResumeDelay: TimeInterval = 0.15
+    private var mouseIsDraggingRuler = false
 
     var preferencesWindowOpen = false {
         didSet {
@@ -88,6 +89,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
 
     func windowDidMove(_ notification: Notification) {
         rulerWindow.invalidateShadow()
+        guard !mouseIsDraggingRuler else { return }
         scheduleMouseTickResume()
     }
 
@@ -110,14 +112,19 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     override func mouseDown(with event: NSEvent) {
+        mouseIsDraggingRuler = true
+        disableMouseTicks()
         rulerCursorController?.mouseDownInRuler()
     }
 
     override func mouseUp(with event: NSEvent) {
+        mouseIsDraggingRuler = false
+        scheduleMouseTickResume()
         rulerCursorController?.mouseUpInRuler(mouseIsInsideRuler: isMouseInsideRuler(with: event))
     }
 
     override func mouseMoved(with event: NSEvent) {
+        guard !mouseIsDraggingRuler else { return }
         enableMouseTicks()
     }
 

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -255,7 +255,7 @@ final class RulerCoreTests: XCTestCase {
     func testRulerControllerKeepsMouseTicksHiddenWhileDragging() {
         let ruler = Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness))
         let controller = RulerController(ruler: ruler)
-        let event = NSEvent.mouseEvent(
+        let mouseDownEvent = NSEvent.mouseEvent(
             with: .leftMouseDown,
             location: NSPoint(x: 10, y: 10),
             modifierFlags: [],
@@ -266,14 +266,25 @@ final class RulerCoreTests: XCTestCase {
             clickCount: 1,
             pressure: 1
         )!
+        let mouseUpEvent = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: NSPoint(x: 10, y: 10),
+            modifierFlags: [],
+            timestamp: 0.1,
+            windowNumber: controller.rulerWindow.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 0
+        )!
 
-        controller.mouseDown(with: event)
+        controller.mouseDown(with: mouseDownEvent)
         controller.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: controller.rulerWindow))
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
 
         XCTAssertFalse(controller.rulerWindow.rule.showMouseTick)
 
-        controller.mouseUp(with: event)
+        controller.mouseUp(with: mouseUpEvent)
         RunLoop.current.run(until: Date().addingTimeInterval(0.2))
 
         XCTAssertTrue(controller.rulerWindow.rule.showMouseTick)

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -251,4 +251,31 @@ final class RulerCoreTests: XCTestCase {
 
         XCTAssertEqual(policy.desiredInterval, 1 / 60)
     }
+
+    func testRulerControllerKeepsMouseTicksHiddenWhileDragging() {
+        let ruler = Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness))
+        let controller = RulerController(ruler: ruler)
+        let event = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 10, y: 10),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: controller.rulerWindow.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+
+        controller.mouseDown(with: event)
+        controller.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: controller.rulerWindow))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        XCTAssertFalse(controller.rulerWindow.rule.showMouseTick)
+
+        controller.mouseUp(with: event)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        XCTAssertTrue(controller.rulerWindow.rule.showMouseTick)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #175 by keeping mouse ticks suppressed for the full ruler drag gesture.

## Root Cause

`windowDidMove` fires repeatedly while a borderless ruler window is being dragged. Each move notification scheduled the delayed mouse tick resume timer, so a small cursor shake during a drag could let that timer re-enable mouse ticks before the mouse button was released.

## Changes

- Track active ruler dragging in `RulerController`.
- Disable mouse ticks on mouse down.
- Ignore move-triggered resume scheduling while dragging.
- Schedule the normal delayed tick resume only after mouse up.
- Add a regression test that simulates move notifications during a drag and verifies ticks stay hidden until release.

## Validation

- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" -only-testing:FreeRulerTests/RulerCoreTests test`
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test`