### PR TITLE
Fix resize handle drag behavior

### DIFF
--- a/Free Ruler/ResizeHandleView.swift
+++ b/Free Ruler/ResizeHandleView.swift
@@ -86,13 +86,14 @@ final class ResizeHandleView: NSView {
         dragInitialMouseLocation = screenLocation(for: event, in: window)
         dragInitialWindowFrame = window.frame
         wasMovableByWindowBackgroundBeforeDrag = window.isMovableByWindowBackground
-        childWindowFramesBeforeDrag = window.childWindows?.map { ($0, $0.frame) } ?? []
 
         window.isMovableByWindowBackground = false
+        window.makeKey()
+
+        childWindowFramesBeforeDrag = window.childWindows?.map { ($0, $0.frame) } ?? []
         for childWindow in childWindowFramesBeforeDrag.map(\.window) {
             window.removeChildWindow(childWindow)
         }
-        window.makeKey()
     }
 
     override func mouseDragged(with event: NSEvent) {

--- a/Free Ruler/ResizeHandleView.swift
+++ b/Free Ruler/ResizeHandleView.swift
@@ -265,25 +265,15 @@ private func clamp(_ value: CGFloat, _ minValue: CGFloat, _ maxValue: CGFloat) -
 }
 
 private func windowResizeCursor(for orientation: Orientation) -> NSCursor {
-    let selectorName: String
-    let fallback: NSCursor
-
+    // Public AppKit cursors keep App Store review safe. The private two-arrow
+    // variants to revisit for non-App-Store builds are `_windowResizeEastWestCursor`
+    // and `_windowResizeNorthSouthCursor`.
     switch orientation {
     case .horizontal:
-        selectorName = "_windowResizeEastWestCursor"
-        fallback = .resizeLeftRight
+        return .resizeLeftRight
     case .vertical:
-        selectorName = "_windowResizeNorthSouthCursor"
-        fallback = .resizeUpDown
+        return .resizeUpDown
     }
-
-    let selector = NSSelectorFromString(selectorName)
-    guard NSCursor.responds(to: selector),
-          let cursor = NSCursor.perform(selector)?.takeUnretainedValue() as? NSCursor else {
-        return fallback
-    }
-
-    return cursor
 }
 
 private func resizeHandleAccessibilityIdentifier(for orientation: Orientation) -> String {

--- a/Free Ruler/ResizeHandleView.swift
+++ b/Free Ruler/ResizeHandleView.swift
@@ -4,6 +4,11 @@ final class ResizeHandleView: NSView {
 
     private let color: RulerColors
     private let orientation: Orientation
+    private var trackingArea: NSTrackingArea?
+    private var dragInitialMouseLocation: NSPoint?
+    private var dragInitialWindowFrame: NSRect?
+    private var wasMovableByWindowBackgroundBeforeDrag: Bool?
+    private var childWindowFramesBeforeDrag: [(window: NSWindow, frame: NSRect)] = []
 
     private let length: CGFloat = 12
     private let lineCount = 4
@@ -19,6 +24,9 @@ final class ResizeHandleView: NSView {
         self.orientation = orientation
         self.color = color
         super.init(frame: .zero)
+
+        setAccessibilityElement(true)
+        setAccessibilityIdentifier(resizeHandleAccessibilityIdentifier(for: orientation))
     }
 
     required init?(coder: NSCoder) {
@@ -30,6 +38,102 @@ final class ResizeHandleView: NSView {
 
         drawBackground()
         drawGripLines()
+    }
+
+    override func updateTrackingAreas() {
+        if let trackingArea = trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+
+        trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [
+                .activeAlways,
+                .cursorUpdate,
+                .inVisibleRect,
+                .mouseEnteredAndExited,
+            ],
+            owner: self,
+            userInfo: nil
+        )
+
+        addTrackingArea(trackingArea!)
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: windowResizeCursor(for: orientation))
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        windowResizeCursor(for: orientation).set()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        windowResizeCursor(for: orientation).set()
+    }
+
+    override var mouseDownCanMoveWindow: Bool {
+        return false
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        return true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let window = window else { return }
+
+        dragInitialMouseLocation = screenLocation(for: event, in: window)
+        dragInitialWindowFrame = window.frame
+        wasMovableByWindowBackgroundBeforeDrag = window.isMovableByWindowBackground
+        childWindowFramesBeforeDrag = window.childWindows?.map { ($0, $0.frame) } ?? []
+
+        window.isMovableByWindowBackground = false
+        for childWindow in childWindowFramesBeforeDrag.map(\.window) {
+            window.removeChildWindow(childWindow)
+        }
+        window.makeKey()
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let window = window,
+              let dragInitialMouseLocation = dragInitialMouseLocation,
+              let dragInitialWindowFrame = dragInitialWindowFrame else { return }
+
+        let mouseLocation = screenLocation(for: event, in: window)
+        let delta = NSSize(
+            width: mouseLocation.x - dragInitialMouseLocation.x,
+            height: mouseLocation.y - dragInitialMouseLocation.y
+        )
+        let nextFrame = resizedRulerFrame(
+            orientation: orientation,
+            initialFrame: dragInitialWindowFrame,
+            delta: delta,
+            minSize: window.minSize,
+            maxSize: window.maxSize
+        )
+
+        window.setFrame(nextFrame, display: true)
+        for (childWindow, childFrame) in childWindowFramesBeforeDrag {
+            childWindow.setFrame(childFrame, display: false)
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard let window = window else {
+            resetDragState()
+            return
+        }
+
+        if let wasMovableByWindowBackgroundBeforeDrag = wasMovableByWindowBackgroundBeforeDrag {
+            window.isMovableByWindowBackground = wasMovableByWindowBackgroundBeforeDrag
+        }
+        for (childWindow, childFrame) in childWindowFramesBeforeDrag {
+            childWindow.setFrame(childFrame, display: false)
+            window.addChildWindow(childWindow, ordered: .below)
+        }
+
+        resetDragState()
     }
 
     func frame(in bounds: NSRect) -> NSRect {
@@ -116,4 +220,77 @@ final class ResizeHandleView: NSView {
         path.stroke()
     }
 
+    private func resetDragState() {
+        dragInitialMouseLocation = nil
+        dragInitialWindowFrame = nil
+        wasMovableByWindowBackgroundBeforeDrag = nil
+        childWindowFramesBeforeDrag = []
+    }
+
+}
+
+private func screenLocation(for event: NSEvent, in window: NSWindow) -> NSPoint {
+    return window.convertPoint(toScreen: event.locationInWindow)
+}
+
+func resizedRulerFrame(
+    orientation: Orientation,
+    initialFrame: NSRect,
+    delta: NSSize,
+    minSize: NSSize,
+    maxSize: NSSize
+) -> NSRect {
+    switch orientation {
+    case .horizontal:
+        let width = clamp(initialFrame.width + delta.width, minSize.width, maxSize.width)
+        return NSRect(
+            x: initialFrame.minX,
+            y: initialFrame.minY,
+            width: width,
+            height: initialFrame.height
+        )
+    case .vertical:
+        let height = clamp(initialFrame.height - delta.height, minSize.height, maxSize.height)
+        return NSRect(
+            x: initialFrame.minX,
+            y: initialFrame.maxY - height,
+            width: initialFrame.width,
+            height: height
+        )
+    }
+}
+
+private func clamp(_ value: CGFloat, _ minValue: CGFloat, _ maxValue: CGFloat) -> CGFloat {
+    return min(max(value, minValue), maxValue)
+}
+
+private func windowResizeCursor(for orientation: Orientation) -> NSCursor {
+    let selectorName: String
+    let fallback: NSCursor
+
+    switch orientation {
+    case .horizontal:
+        selectorName = "_windowResizeEastWestCursor"
+        fallback = .resizeLeftRight
+    case .vertical:
+        selectorName = "_windowResizeNorthSouthCursor"
+        fallback = .resizeUpDown
+    }
+
+    let selector = NSSelectorFromString(selectorName)
+    guard NSCursor.responds(to: selector),
+          let cursor = NSCursor.perform(selector)?.takeUnretainedValue() as? NSCursor else {
+        return fallback
+    }
+
+    return cursor
+}
+
+private func resizeHandleAccessibilityIdentifier(for orientation: Orientation) -> String {
+    switch orientation {
+    case .horizontal:
+        return "horizontal-resize-handle"
+    case .vertical:
+        return "vertical-resize-handle"
+    }
 }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -252,6 +252,150 @@ final class RulerCoreTests: XCTestCase {
         XCTAssertEqual(policy.desiredInterval, 1 / 60)
     }
 
+    func testHorizontalResizeHandleFrameMathResizesOnlyWidthFromRightEdge() {
+        let initialFrame = NSRect(x: 10, y: 20, width: 300, height: Ruler.thickness)
+        let frame = resizedRulerFrame(
+            orientation: .horizontal,
+            initialFrame: initialFrame,
+            delta: NSSize(width: 50, height: 25),
+            minSize: NSSize(width: 200, height: Ruler.thickness),
+            maxSize: NSSize(width: 4000, height: Ruler.thickness)
+        )
+
+        XCTAssertEqual(frame, NSRect(x: 10, y: 20, width: 350, height: Ruler.thickness))
+    }
+
+    func testHorizontalResizeHandleFrameMathClampsWidth() {
+        let initialFrame = NSRect(x: 10, y: 20, width: 300, height: Ruler.thickness)
+        let frame = resizedRulerFrame(
+            orientation: .horizontal,
+            initialFrame: initialFrame,
+            delta: NSSize(width: -250, height: 0),
+            minSize: NSSize(width: 200, height: Ruler.thickness),
+            maxSize: NSSize(width: 4000, height: Ruler.thickness)
+        )
+
+        XCTAssertEqual(frame, NSRect(x: 10, y: 20, width: 200, height: Ruler.thickness))
+    }
+
+    func testVerticalResizeHandleFrameMathResizesOnlyHeightFromBottomEdge() {
+        let initialFrame = NSRect(x: 10, y: 20, width: Ruler.thickness, height: 300)
+        let frame = resizedRulerFrame(
+            orientation: .vertical,
+            initialFrame: initialFrame,
+            delta: NSSize(width: 25, height: -50),
+            minSize: NSSize(width: Ruler.thickness, height: 200),
+            maxSize: NSSize(width: Ruler.thickness, height: 4000)
+        )
+
+        XCTAssertEqual(frame, NSRect(x: 10, y: -30, width: Ruler.thickness, height: 350))
+        XCTAssertEqual(frame.maxY, initialFrame.maxY)
+    }
+
+    func testVerticalResizeHandleFrameMathClampsHeightWhileKeepingTopEdgeFixed() {
+        let initialFrame = NSRect(x: 10, y: 20, width: Ruler.thickness, height: 300)
+        let frame = resizedRulerFrame(
+            orientation: .vertical,
+            initialFrame: initialFrame,
+            delta: NSSize(width: 0, height: 250),
+            minSize: NSSize(width: Ruler.thickness, height: 200),
+            maxSize: NSSize(width: Ruler.thickness, height: 4000)
+        )
+
+        XCTAssertEqual(frame, NSRect(x: 10, y: 120, width: Ruler.thickness, height: 200))
+        XCTAssertEqual(frame.maxY, initialFrame.maxY)
+    }
+
+    func testResizeHandleDisablesWindowBackgroundDraggingDuringResizeDrag() {
+        let ruler = Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness))
+        let window = RulerWindow(ruler)
+        guard let resizeHandle = window.rule.subviews.first(where: { $0 is ResizeHandleView }) as? ResizeHandleView else {
+            return XCTFail("Expected horizontal ruler to install a resize handle")
+        }
+
+        XCTAssertTrue(window.isMovableByWindowBackground)
+
+        let mouseDownEvent = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: resizeHandle.convert(NSPoint(x: 1, y: 1), to: nil),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+        let mouseUpEvent = NSEvent.mouseEvent(
+            with: .leftMouseUp,
+            location: resizeHandle.convert(NSPoint(x: 1, y: 1), to: nil),
+            modifierFlags: [],
+            timestamp: 0.1,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 0
+        )!
+
+        resizeHandle.mouseDown(with: mouseDownEvent)
+        XCTAssertFalse(window.isMovableByWindowBackground)
+
+        resizeHandle.mouseUp(with: mouseUpEvent)
+        XCTAssertTrue(window.isMovableByWindowBackground)
+    }
+
+    func testHorizontalResizeHandleDragKeepsLeftAndTopEdgesFixed() {
+        let initialFrame = NSRect(x: 100, y: 200, width: 300, height: Ruler.thickness)
+        let ruler = Ruler(.horizontal, frame: initialFrame)
+        let window = RulerWindow(ruler)
+        guard let resizeHandle = window.rule.subviews.first(where: { $0 is ResizeHandleView }) as? ResizeHandleView else {
+            return XCTFail("Expected horizontal ruler to install a resize handle")
+        }
+
+        let startLocation = resizeHandle.convert(
+            NSPoint(x: resizeHandle.bounds.minX + 1, y: resizeHandle.bounds.midY),
+            to: nil
+        )
+        let mouseDownEvent = mouseEvent(
+            type: .leftMouseDown,
+            location: startLocation,
+            windowNumber: window.windowNumber,
+            timestamp: 0
+        )
+
+        resizeHandle.mouseDown(with: mouseDownEvent)
+
+        let dragOffsets = [
+            NSSize(width: -40, height: 0),
+            NSSize(width: 80, height: 0),
+            NSSize(width: 0, height: 30),
+            NSSize(width: 0, height: -30),
+        ]
+
+        for (index, offset) in dragOffsets.enumerated() {
+            let dragEvent = mouseEvent(
+                type: .leftMouseDragged,
+                location: NSPoint(x: startLocation.x + offset.width, y: startLocation.y + offset.height),
+                windowNumber: window.windowNumber,
+                timestamp: TimeInterval(index + 1) * 0.1
+            )
+
+            resizeHandle.mouseDragged(with: dragEvent)
+
+            XCTAssertEqual(window.frame.minX, initialFrame.minX, "left edge moved for drag offset \(offset)")
+            XCTAssertEqual(window.frame.maxY, initialFrame.maxY, "top edge moved for drag offset \(offset)")
+        }
+
+        let mouseUpEvent = mouseEvent(
+            type: .leftMouseUp,
+            location: startLocation,
+            windowNumber: window.windowNumber,
+            timestamp: 1
+        )
+        resizeHandle.mouseUp(with: mouseUpEvent)
+    }
+
     func testRulerControllerKeepsMouseTicksHiddenWhileDragging() {
         let ruler = Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness))
         let controller = RulerController(ruler: ruler)
@@ -351,5 +495,24 @@ final class RulerCoreTests: XCTestCase {
 
         XCTAssertFalse(draggedController.rulerWindow.rule.showMouseTick)
         XCTAssertFalse(groupedChildController.rulerWindow.rule.showMouseTick)
+    }
+
+    private func mouseEvent(
+        type: NSEvent.EventType,
+        location: NSPoint,
+        windowNumber: Int,
+        timestamp: TimeInterval
+    ) -> NSEvent {
+        return NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: timestamp,
+            windowNumber: windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: type == .leftMouseUp ? 0 : 1
+        )!
     }
 }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -345,6 +345,38 @@ final class RulerCoreTests: XCTestCase {
         XCTAssertTrue(window.isMovableByWindowBackground)
     }
 
+    func testResizeHandleDetachesChildWindowsAttachedWhileBecomingKey() {
+        let childWindow = RulerWindow(
+            Ruler(.vertical, frame: NSRect(x: 0, y: 0, width: Ruler.thickness, height: 300))
+        )
+        let window = ChildAttachingRulerWindow(
+            ruler: Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness)),
+            childWindow: childWindow
+        )
+        guard let resizeHandle = window.rule.subviews.first(where: { $0 is ResizeHandleView }) as? ResizeHandleView else {
+            return XCTFail("Expected horizontal ruler to install a resize handle")
+        }
+        let location = resizeHandle.convert(NSPoint(x: 1, y: 1), to: nil)
+
+        resizeHandle.mouseDown(with: mouseEvent(
+            type: .leftMouseDown,
+            location: location,
+            windowNumber: window.windowNumber,
+            timestamp: 0
+        ))
+
+        XCTAssertFalse(window.childWindows?.contains(childWindow) ?? false)
+
+        resizeHandle.mouseUp(with: mouseEvent(
+            type: .leftMouseUp,
+            location: location,
+            windowNumber: window.windowNumber,
+            timestamp: 0.1
+        ))
+
+        XCTAssertTrue(window.childWindows?.contains(childWindow) ?? false)
+    }
+
     func testHorizontalResizeHandleDragKeepsLeftAndTopEdgesFixed() {
         let initialFrame = NSRect(x: 100, y: 200, width: 300, height: Ruler.thickness)
         let ruler = Ruler(.horizontal, frame: initialFrame)
@@ -514,5 +546,19 @@ final class RulerCoreTests: XCTestCase {
             clickCount: 1,
             pressure: type == .leftMouseUp ? 0 : 1
         )!
+    }
+}
+
+private final class ChildAttachingRulerWindow: RulerWindow {
+    private let childWindowToAttach: NSWindow
+
+    init(ruler: Ruler, childWindow: NSWindow) {
+        self.childWindowToAttach = childWindow
+        super.init(ruler: ruler)
+    }
+
+    override func makeKey() {
+        super.makeKey()
+        addChildWindow(childWindowToAttach, ordered: .below)
     }
 }


### PR DESCRIPTION
Closes #177 

## Summary
- route resize-handle dragging through explicit frame resizing instead of window background dragging
- preserve grouped child window frames while handle resize is active
- add core tests for resize frame math, background dragging suppression, and fixed top/left edges during horizontal handle drags

## Tests
- xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test