### PR TITLE
[codex] Fix mouse tick resume after ruler drag

### DIFF
--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -118,6 +118,12 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     override func mouseUp(with event: NSEvent) {
+        finishMouseDrag(with: event)
+    }
+
+    func finishMouseDrag(with event: NSEvent) {
+        guard mouseIsDraggingRuler else { return }
+
         mouseIsDraggingRuler = false
         scheduleMouseTickResume()
         rulerCursorController?.mouseUpInRuler(mouseIsInsideRuler: isMouseInsideRuler(with: event))

--- a/Free Ruler/RulerController.swift
+++ b/Free Ruler/RulerController.swift
@@ -16,6 +16,9 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     private var mouseTickResumeTimer: Timer?
     private let mouseTickResumeDelay: TimeInterval = 0.15
     private var mouseIsDraggingRuler = false
+    var isLeftMouseButtonPressed = {
+        return NSEvent.pressedMouseButtons & 1 == 1
+    }
 
     var preferencesWindowOpen = false {
         didSet {
@@ -89,7 +92,7 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
 
     func windowDidMove(_ notification: Notification) {
         rulerWindow.invalidateShadow()
-        guard !mouseIsDraggingRuler else { return }
+        guard !mouseIsDraggingRuler && !isLeftMouseButtonPressed() else { return }
         scheduleMouseTickResume()
     }
 
@@ -143,8 +146,6 @@ class RulerController: NSWindowController, NSWindowDelegate, NotificationObserve
     }
 
     func enableMouseTicks() {
-        guard !rulerWindow.rule.showMouseTick || otherWindow?.rule.showMouseTick == false else { return }
-
         rulerWindow.rule.showMouseTick = true
         otherWindow?.rule.showMouseTick = true
         appDelegate?.resumeMouseTickUpdates(owner: self)

--- a/Free Ruler/RulerWindow.swift
+++ b/Free Ruler/RulerWindow.swift
@@ -60,11 +60,19 @@ class RulerWindow: NSPanel {
     override func mouseDown(with event: NSEvent) {
         nextResponder?.mouseDown(with: event)
         super.mouseDown(with: event)
+
+        if !leftMouseButtonIsPressed {
+            (nextResponder as? RulerController)?.finishMouseDrag(with: event)
+        }
     }
 
     override func mouseUp(with event: NSEvent) {
         nextResponder?.mouseUp(with: event)
         super.mouseUp(with: event)
+    }
+
+    private var leftMouseButtonIsPressed: Bool {
+        return NSEvent.pressedMouseButtons & 1 == 1
     }
 
 }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -320,4 +320,36 @@ final class RulerCoreTests: XCTestCase {
         XCTAssertTrue(controller.rulerWindow.rule.showMouseTick)
         XCTAssertTrue(otherWindow.rule.showMouseTick)
     }
+
+    func testGroupedChildMoveDoesNotResumeMouseTicksDuringDrag() {
+        let draggedController = RulerController(
+            ruler: Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness))
+        )
+        let groupedChildController = RulerController(
+            ruler: Ruler(.vertical, frame: NSRect(x: 0, y: 0, width: Ruler.thickness, height: 300))
+        )
+        draggedController.otherWindow = groupedChildController.rulerWindow
+        groupedChildController.otherWindow = draggedController.rulerWindow
+        groupedChildController.isLeftMouseButtonPressed = { true }
+        let mouseDownEvent = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 10, y: 10),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: draggedController.rulerWindow.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+
+        draggedController.mouseDown(with: mouseDownEvent)
+        groupedChildController.windowDidMove(
+            Notification(name: NSWindow.didMoveNotification, object: groupedChildController.rulerWindow)
+        )
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        XCTAssertFalse(draggedController.rulerWindow.rule.showMouseTick)
+        XCTAssertFalse(groupedChildController.rulerWindow.rule.showMouseTick)
+    }
 }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -289,4 +289,35 @@ final class RulerCoreTests: XCTestCase {
 
         XCTAssertTrue(controller.rulerWindow.rule.showMouseTick)
     }
+
+    func testRulerControllerResumesMouseTicksWhenWindowDragLoopEnds() {
+        let ruler = Ruler(.horizontal, frame: NSRect(x: 0, y: 0, width: 300, height: Ruler.thickness))
+        let controller = RulerController(ruler: ruler)
+        let otherWindow = RulerWindow(Ruler(.vertical, frame: NSRect(x: 0, y: 0, width: Ruler.thickness, height: 300)))
+        controller.otherWindow = otherWindow
+        let mouseDownEvent = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 10, y: 10),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: controller.rulerWindow.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+
+        controller.mouseDown(with: mouseDownEvent)
+        controller.windowDidMove(Notification(name: NSWindow.didMoveNotification, object: controller.rulerWindow))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        XCTAssertFalse(controller.rulerWindow.rule.showMouseTick)
+        XCTAssertFalse(otherWindow.rule.showMouseTick)
+
+        controller.finishMouseDrag(with: mouseDownEvent)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+
+        XCTAssertTrue(controller.rulerWindow.rule.showMouseTick)
+        XCTAssertTrue(otherWindow.rule.showMouseTick)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #181 by making ruler window drags explicitly finish the mouse tick suspension path when AppKit's borderless-window drag loop returns.

## Root Cause

PR #176 suppresses mouse ticks while a ruler is being dragged and expects the normal mouse-up responder path to resume them. For borderless movable panels, `super.mouseDown(with:)` can own the drag loop, so the controller may not receive a normal `mouseUp` after the drag. That leaves the controller in its dragging state and keeps tick resume behavior stuck until another click.

## Changes

- Move ruler drag completion into `RulerController.finishMouseDrag(with:)`.
- Have `RulerWindow.mouseDown(with:)` call that completion path once AppKit's drag loop returns and the left mouse button is no longer pressed.
- Add regression coverage that verifies both ruler ticks resume after the window-drag completion path.

## Validation

- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" -only-testing:FreeRulerTests/RulerCoreTests test`
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test`