### PR TITLE
[codex] Make ruler side types axis-specific

### DIFF
--- a/Free Ruler/HorizontalRule.swift
+++ b/Free Ruler/HorizontalRule.swift
@@ -40,7 +40,7 @@ class HorizontalRule: RuleView {
         let path = NSBezierPath()
         let tickLayout = RulerTickLayout(unit: unit, screen: screen)
         let geometry = ZeroCornerGeometry(zeroCorner: zeroCorner)
-        let tickSide = geometry.tickSide(for: .horizontal)
+        let tickSide = geometry.horizontalTickSide
         let growthDirection = geometry.growthDirection(for: .horizontal)
 
         let labelWidth: CGFloat = 50
@@ -206,16 +206,13 @@ class HorizontalRule: RuleView {
         forX x: CGFloat,
         length: CGFloat,
         rulerHeight: CGFloat,
-        tickSide: RulerSide
+        tickSide: RulerVerticalSide
     ) -> (start: CGPoint, end: CGPoint) {
         switch tickSide {
         case .bottom:
             return (CGPoint(x: x, y: 1), CGPoint(x: x, y: length))
         case .top:
             return (CGPoint(x: x, y: rulerHeight - 1), CGPoint(x: x, y: rulerHeight - length))
-        case .left, .right:
-            assertionFailure("Horizontal ruler ticks must be placed on a horizontal side")
-            return (CGPoint(x: x, y: 1), CGPoint(x: x, y: length))
         }
     }
 
@@ -223,7 +220,7 @@ class HorizontalRule: RuleView {
         forX x: CGFloat,
         labelSize: NSSize,
         rulerHeight: CGFloat,
-        tickSide: RulerSide
+        tickSide: RulerVerticalSide
     ) -> CGRect {
         let labelOffset: CGFloat = 13
         let textHeight: CGFloat = 8
@@ -235,9 +232,6 @@ class HorizontalRule: RuleView {
             labelY = labelOffset
         case .top:
             labelY = rulerHeight - labelOffset - textHeight
-        case .left, .right:
-            assertionFailure("Horizontal ruler labels must be placed on a horizontal side")
-            labelY = labelOffset
         }
 
         return CGRect(x: labelX, y: labelY, width: labelSize.width, height: labelSize.height)

--- a/Free Ruler/ResizeHandleView.swift
+++ b/Free Ruler/ResizeHandleView.swift
@@ -185,12 +185,6 @@ final class ResizeHandleView: NSView {
                     - horizontalXOffset
                     - CGFloat(lineCount - 1) * lineSpacing
                     - 1
-            case .top, .bottom:
-                assertionFailure("Horizontal resize handle must be placed on a horizontal side")
-                firstX = bounds.maxX
-                    - horizontalXOffset
-                    - CGFloat(lineCount - 1) * lineSpacing
-                    - 1
             }
 
             switch placement.ySide {
@@ -198,9 +192,6 @@ final class ResizeHandleView: NSView {
                 bottomY = bounds.maxY - horizontalYOffset - length
             case .bottom:
                 bottomY = bounds.minY + horizontalYOffset
-            case .left, .right:
-                assertionFailure("Horizontal resize handle must be placed on a vertical side")
-                bottomY = bounds.maxY - horizontalYOffset - length
             }
 
             return NSRect(
@@ -218,9 +209,6 @@ final class ResizeHandleView: NSView {
                 leftX = bounds.minX + verticalXOffset
             case .right:
                 leftX = bounds.maxX - verticalXOffset - length
-            case .top, .bottom:
-                assertionFailure("Vertical resize handle must be placed on a horizontal side")
-                leftX = bounds.minX + verticalXOffset
             }
 
             switch placement.ySide {
@@ -230,9 +218,6 @@ final class ResizeHandleView: NSView {
                     - CGFloat(lineCount - 1) * lineSpacing
                     - 1
             case .bottom:
-                firstY = bounds.minY + verticalYOffset + 1
-            case .left, .right:
-                assertionFailure("Vertical resize handle must be placed on a vertical side")
                 firstY = bounds.minY + verticalYOffset + 1
             }
 
@@ -262,10 +247,6 @@ final class ResizeHandleView: NSView {
         case .right:
             x = gripFrame.minX
             width = bounds.maxX - gripFrame.minX
-        case .top, .bottom:
-            assertionFailure("Resize handle slot must be anchored to a horizontal side")
-            x = gripFrame.minX
-            width = gripFrame.width
         }
 
         switch placement.ySide {
@@ -275,10 +256,6 @@ final class ResizeHandleView: NSView {
         case .bottom:
             y = bounds.minY
             height = gripFrame.maxY - bounds.minY
-        case .left, .right:
-            assertionFailure("Resize handle slot must be anchored to a vertical side")
-            y = gripFrame.minY
-            height = gripFrame.height
         }
 
         return NSRect(x: x, y: y, width: width, height: height)
@@ -343,9 +320,6 @@ final class ResizeHandleView: NSView {
             x = bounds.maxX - gripSize.width
         case .right:
             x = bounds.minX
-        case .top, .bottom:
-            assertionFailure("Resize handle grip must be anchored to a horizontal side")
-            x = bounds.minX
         }
 
         switch placement.ySide {
@@ -353,9 +327,6 @@ final class ResizeHandleView: NSView {
             y = bounds.minY
         case .bottom:
             y = bounds.maxY - gripSize.height
-        case .left, .right:
-            assertionFailure("Resize handle grip must be anchored to a vertical side")
-            y = bounds.minY
         }
 
         return NSRect(origin: NSPoint(x: x, y: y), size: gripSize)
@@ -423,11 +394,11 @@ func resizedRulerFrame(
     minSize: NSSize,
     maxSize: NSSize
 ) -> NSRect {
-    let resizeSide = ZeroCornerGeometry(zeroCorner: zeroCorner).resizeSide(for: orientation)
+    let geometry = ZeroCornerGeometry(zeroCorner: zeroCorner)
 
     switch orientation {
     case .horizontal:
-        switch resizeSide {
+        switch geometry.horizontalResizeSide {
         case .left:
             let width = clamp(initialFrame.width - delta.width, minSize.width, maxSize.width)
             return NSRect(
@@ -444,12 +415,9 @@ func resizedRulerFrame(
                 width: width,
                 height: initialFrame.height
             )
-        case .top, .bottom:
-            assertionFailure("Horizontal ruler resize side must be left or right")
-            return initialFrame
         }
     case .vertical:
-        switch resizeSide {
+        switch geometry.verticalResizeSide {
         case .top:
             let height = clamp(initialFrame.height + delta.height, minSize.height, maxSize.height)
             return NSRect(
@@ -466,9 +434,6 @@ func resizedRulerFrame(
                 width: initialFrame.width,
                 height: height
             )
-        case .left, .right:
-            assertionFailure("Vertical ruler resize side must be top or bottom")
-            return initialFrame
         }
     }
 }

--- a/Free Ruler/RuleView.swift
+++ b/Free Ruler/RuleView.swift
@@ -72,8 +72,8 @@ struct MouseTickLabelLayout {
         let x: CGFloat
         let y: CGFloat
 
-        switch (orientation, placement.xSide, placement.ySide) {
-        case (.horizontal, .left, .top), (.horizontal, .right, .top):
+        switch orientation {
+        case .horizontal:
             x = horizontalX(
                 forTickX: tickPosition,
                 labelSize: labelSize,
@@ -83,23 +83,18 @@ struct MouseTickLabelLayout {
                 unitLabelFrame: unitLabelFrame,
                 offsets: offsets
             )
-            y = rulerSize.height - labelSize.height - offsets.topInset
-        case (.horizontal, .left, .bottom), (.horizontal, .right, .bottom):
-            x = horizontalX(
-                forTickX: tickPosition,
-                labelSize: labelSize,
-                rulerSize: rulerSize,
-                zeroCorner: zeroCorner,
-                resizeHandleFrame: resizeHandleFrame,
-                unitLabelFrame: unitLabelFrame,
-                offsets: offsets
-            )
-            y = offsets.bottomInset
-        case (.vertical, .left, .top), (.vertical, .left, .bottom):
+
+            switch placement.ySide {
+            case .top:
+                y = rulerSize.height - labelSize.height - offsets.topInset
+            case .bottom:
+                y = offsets.bottomInset
+            }
+        case .vertical:
             x = verticalX(
                 labelSize: labelSize,
                 rulerSize: rulerSize,
-                tickSide: geometry.tickSide(for: .vertical),
+                tickSide: geometry.verticalTickSide,
                 placement: placement,
                 offsets: offsets
             )
@@ -112,27 +107,6 @@ struct MouseTickLabelLayout {
                 unitLabelFrame: unitLabelFrame,
                 offsets: offsets
             )
-        case (.vertical, .right, .top), (.vertical, .right, .bottom):
-            x = verticalX(
-                labelSize: labelSize,
-                rulerSize: rulerSize,
-                tickSide: geometry.tickSide(for: .vertical),
-                placement: placement,
-                offsets: offsets
-            )
-            y = verticalY(
-                forTickY: tickPosition,
-                labelSize: labelSize,
-                rulerSize: rulerSize,
-                zeroCorner: zeroCorner,
-                resizeHandleFrame: resizeHandleFrame,
-                unitLabelFrame: unitLabelFrame,
-                offsets: offsets
-            )
-        case (_, _, _):
-            assertionFailure("Mouse tick label must be anchored to left/right and top/bottom sides")
-            x = offsets.leftInset
-            y = offsets.bottomInset
         }
 
         return NSRect(x: x, y: y, width: labelSize.width, height: labelSize.height)
@@ -172,7 +146,7 @@ struct MouseTickLabelLayout {
 
         return verticalLabelLaneFrame(
             rulerSize: rulerSize,
-            tickSide: geometry.tickSide(for: .vertical),
+            tickSide: geometry.verticalTickSide,
             y: labelFrame.minY,
             height: labelFrame.height
         ).union(labelFrame)
@@ -182,26 +156,16 @@ struct MouseTickLabelLayout {
         for orientation: Orientation,
         placement: RulerCornerPlacement
     ) -> Offsets {
-        switch (orientation, placement.xSide, placement.ySide) {
-        case (.horizontal, .left, .top):
-            return Offsets(topInset: 2, bottomInset: 2, leftInset: 0, rightInset: 0, tickLabelSpacing: 5)
-        case (.horizontal, .right, .top):
-            return Offsets(topInset: 2, bottomInset: 2, leftInset: 0, rightInset: 0, tickLabelSpacing: 5)
-        case (.horizontal, .left, .bottom):
-            return Offsets(topInset: 2, bottomInset: 7, leftInset: 5, rightInset: 0, tickLabelSpacing: 5)
-        case (.horizontal, .right, .bottom):
-            return Offsets(topInset: 2, bottomInset: 7, leftInset: 5, rightInset: 0, tickLabelSpacing: 5)
-        case (.vertical, .left, .top):
+        switch orientation {
+        case .horizontal:
+            switch placement.ySide {
+            case .top:
+                return Offsets(topInset: 2, bottomInset: 2, leftInset: 0, rightInset: 0, tickLabelSpacing: 5)
+            case .bottom:
+                return Offsets(topInset: 2, bottomInset: 7, leftInset: 5, rightInset: 0, tickLabelSpacing: 5)
+            }
+        case .vertical:
             return Offsets(topInset: 2, bottomInset: 2, leftInset: 7, rightInset: 7, tickLabelSpacing: 4)
-        case (.vertical, .right, .top):
-            return Offsets(topInset: 2, bottomInset: 2, leftInset: 7, rightInset: 7, tickLabelSpacing: 4)
-        case (.vertical, .left, .bottom):
-            return Offsets(topInset: 2, bottomInset: 2, leftInset: 7, rightInset: 7, tickLabelSpacing: 4)
-        case (.vertical, .right, .bottom):
-            return Offsets(topInset: 2, bottomInset: 2, leftInset: 7, rightInset: 7, tickLabelSpacing: 4)
-        case (_, _, _):
-            assertionFailure("Mouse tick label offsets require left/right and top/bottom placement")
-            return Offsets(topInset: 2, bottomInset: 2, leftInset: 5, rightInset: 5, tickLabelSpacing: 5)
         }
     }
 
@@ -250,14 +214,11 @@ struct MouseTickLabelLayout {
 
         guard let resizeHandleFrame = resizeHandleFrame else { return true }
 
-        switch geometry.resizeSide(for: .horizontal) {
+        switch geometry.horizontalResizeSide {
         case .left:
             return true
         case .right:
             return labelX + labelSize.width <= resizeHandleFrame.minX
-        case .top, .bottom:
-            assertionFailure("Horizontal resize side must be left or right")
-            return true
         }
     }
 
@@ -290,7 +251,7 @@ struct MouseTickLabelLayout {
     private static func verticalX(
         labelSize: NSSize,
         rulerSize: NSSize,
-        tickSide: RulerSide,
+        tickSide: RulerHorizontalSide,
         placement: RulerCornerPlacement,
         offsets: Offsets
     ) -> CGFloat {
@@ -306,15 +267,12 @@ struct MouseTickLabelLayout {
             return laneFrame.minX + offsets.leftInset
         case .right:
             return laneFrame.maxX - labelSize.width - offsets.rightInset
-        case .top, .bottom:
-            assertionFailure("Vertical mouse tick labels must be padded from a left or right lane edge")
-            return laneFrame.minX + offsets.leftInset
         }
     }
 
     private static func verticalLabelLaneFrame(
         rulerSize: NSSize,
-        tickSide: RulerSide,
+        tickSide: RulerHorizontalSide,
         y: CGFloat,
         height: CGFloat
     ) -> NSRect {
@@ -325,9 +283,6 @@ struct MouseTickLabelLayout {
             return NSRect(x: 0, y: y, width: laneWidth, height: height)
         case .left:
             return NSRect(x: rulerSize.width - laneWidth, y: y, width: laneWidth, height: height)
-        case .top, .bottom:
-            assertionFailure("Vertical mouse tick label lane must follow a vertical tick side")
-            return NSRect(x: 0, y: y, width: laneWidth, height: height)
         }
     }
 
@@ -350,13 +305,10 @@ struct MouseTickLabelLayout {
 
         guard let resizeHandleFrame = resizeHandleFrame else { return true }
 
-        switch geometry.resizeSide(for: .vertical) {
+        switch geometry.verticalResizeSide {
         case .bottom:
             return labelY >= resizeHandleFrame.maxY
         case .top:
-            return true
-        case .left, .right:
-            assertionFailure("Vertical resize side must be top or bottom")
             return true
         }
     }

--- a/Free Ruler/Ruler.swift
+++ b/Free Ruler/Ruler.swift
@@ -40,29 +40,37 @@ enum RulerGrowthDirection: Equatable {
     case negative
 }
 
-enum RulerSide: Equatable {
-    case top
-    case right
-    case bottom
+enum RulerHorizontalSide: Equatable {
     case left
+    case right
 
-    var opposite: RulerSide {
+    var opposite: RulerHorizontalSide {
+        switch self {
+        case .left:
+            return .right
+        case .right:
+            return .left
+        }
+    }
+}
+
+enum RulerVerticalSide: Equatable {
+    case top
+    case bottom
+
+    var opposite: RulerVerticalSide {
         switch self {
         case .top:
             return .bottom
-        case .right:
-            return .left
         case .bottom:
             return .top
-        case .left:
-            return .right
         }
     }
 }
 
 struct RulerCornerPlacement: Equatable {
-    let xSide: RulerSide
-    let ySide: RulerSide
+    let xSide: RulerHorizontalSide
+    let ySide: RulerVerticalSide
 }
 
 struct ZeroCornerGeometry {
@@ -83,52 +91,42 @@ struct ZeroCornerGeometry {
         }
     }
 
-    func tickSide(for orientation: Orientation) -> RulerSide {
-        switch orientation {
-        case .horizontal:
-            return verticalZeroSide == .top ? .bottom : .top
-        case .vertical:
-            return horizontalZeroSide == .left ? .right : .left
-        }
+    var horizontalTickSide: RulerVerticalSide {
+        return verticalZeroSide == .top ? .bottom : .top
     }
 
-    func resizeSide(for orientation: Orientation) -> RulerSide {
-        switch orientation {
-        case .horizontal:
-            return horizontalZeroSide == .left ? .right : .left
-        case .vertical:
-            return verticalZeroSide == .top ? .bottom : .top
-        }
+    var verticalTickSide: RulerHorizontalSide {
+        return horizontalZeroSide == .left ? .right : .left
+    }
+
+    var horizontalResizeSide: RulerHorizontalSide {
+        return horizontalZeroSide == .left ? .right : .left
+    }
+
+    var verticalResizeSide: RulerVerticalSide {
+        return verticalZeroSide == .top ? .bottom : .top
     }
 
     func resizeHandlePlacement(for orientation: Orientation) -> RulerCornerPlacement {
         switch orientation {
         case .horizontal:
             return RulerCornerPlacement(
-                xSide: resizeSide(for: orientation),
-                ySide: tickSide(for: orientation).opposite
+                xSide: horizontalZeroSide.opposite,
+                ySide: verticalZeroSide
             )
         case .vertical:
             return RulerCornerPlacement(
-                xSide: tickSide(for: orientation).opposite,
-                ySide: resizeSide(for: orientation)
+                xSide: horizontalZeroSide,
+                ySide: verticalZeroSide.opposite
             )
         }
     }
 
     func unitLabelPlacement(for orientation: Orientation) -> RulerCornerPlacement {
-        switch orientation {
-        case .horizontal:
-            return RulerCornerPlacement(
-                xSide: resizeSide(for: orientation).opposite,
-                ySide: tickSide(for: orientation).opposite
-            )
-        case .vertical:
-            return RulerCornerPlacement(
-                xSide: tickSide(for: orientation).opposite,
-                ySide: resizeSide(for: orientation).opposite
-            )
-        }
+        return RulerCornerPlacement(
+            xSide: horizontalZeroSide,
+            ySide: verticalZeroSide
+        )
     }
 
     func zeroPoint(in frame: NSRect, for orientation: Orientation) -> NSPoint {
@@ -197,7 +195,7 @@ struct ZeroCornerGeometry {
         }
     }
 
-    private var horizontalZeroSide: RulerSide {
+    private var horizontalZeroSide: RulerHorizontalSide {
         switch zeroCorner {
         case .topLeft, .bottomLeft:
             return .left
@@ -206,7 +204,7 @@ struct ZeroCornerGeometry {
         }
     }
 
-    private var verticalZeroSide: RulerSide {
+    private var verticalZeroSide: RulerVerticalSide {
         switch zeroCorner {
         case .topLeft, .topRight:
             return .top

--- a/Free Ruler/Ruler.swift
+++ b/Free Ruler/Ruler.swift
@@ -92,19 +92,19 @@ struct ZeroCornerGeometry {
     }
 
     var horizontalTickSide: RulerVerticalSide {
-        return verticalZeroSide == .top ? .bottom : .top
+        return verticalZeroSide.opposite
     }
 
     var verticalTickSide: RulerHorizontalSide {
-        return horizontalZeroSide == .left ? .right : .left
+        return horizontalZeroSide.opposite
     }
 
     var horizontalResizeSide: RulerHorizontalSide {
-        return horizontalZeroSide == .left ? .right : .left
+        return horizontalZeroSide.opposite
     }
 
     var verticalResizeSide: RulerVerticalSide {
-        return verticalZeroSide == .top ? .bottom : .top
+        return verticalZeroSide.opposite
     }
 
     func resizeHandlePlacement(for orientation: Orientation) -> RulerCornerPlacement {

--- a/Free Ruler/UnitLabelView.swift
+++ b/Free Ruler/UnitLabelView.swift
@@ -94,10 +94,6 @@ final class UnitLabelView: NSView {
         case .right:
             x = rulerSize.width - labelSize.width - Self.padding.right
             width = labelSize.width + Self.padding.right
-        case .top, .bottom:
-            assertionFailure("Unit label must be anchored to a horizontal side")
-            x = 0
-            width = Self.padding.left + labelSize.width
         }
 
         switch placement.ySide {
@@ -105,10 +101,6 @@ final class UnitLabelView: NSView {
             y = rulerSize.height - labelSize.height - Self.padding.top
             height = labelSize.height + Self.padding.top
         case .bottom:
-            y = 0
-            height = Self.padding.bottom + labelSize.height
-        case .left, .right:
-            assertionFailure("Unit label must be anchored to a vertical side")
             y = 0
             height = Self.padding.bottom + labelSize.height
         }
@@ -129,9 +121,6 @@ final class UnitLabelView: NSView {
             x = bounds.maxX - labelSize.width
         case .right:
             x = bounds.minX
-        case .top, .bottom:
-            assertionFailure("Unit label must be anchored to a horizontal side")
-            x = bounds.minX
         }
 
         switch placement.ySide {
@@ -142,9 +131,6 @@ final class UnitLabelView: NSView {
             )
         case .bottom:
             y = bounds.maxY - labelSize.height
-        case .left, .right:
-            assertionFailure("Unit label must be anchored to a vertical side")
-            y = bounds.minY
         }
 
         return NSRect(x: x, y: y, width: labelSize.width, height: labelSize.height)

--- a/Free Ruler/VerticalRule.swift
+++ b/Free Ruler/VerticalRule.swift
@@ -38,7 +38,7 @@ class VerticalRule: RuleView {
         let path = NSBezierPath()
         let tickLayout = RulerTickLayout(unit: unit, screen: screen)
         let geometry = ZeroCornerGeometry(zeroCorner: zeroCorner)
-        let tickSide = geometry.tickSide(for: .vertical)
+        let tickSide = geometry.verticalTickSide
         let growthDirection = geometry.growthDirection(for: .vertical)
         let attrs = labelAttributes(
             alignment: tickSide == .right ? .right : .left,
@@ -228,16 +228,13 @@ class VerticalRule: RuleView {
         forY y: CGFloat,
         length: CGFloat,
         rulerWidth: CGFloat,
-        tickSide: RulerSide
+        tickSide: RulerHorizontalSide
     ) -> (start: CGPoint, end: CGPoint) {
         switch tickSide {
         case .right:
             return (CGPoint(x: rulerWidth - 1, y: y), CGPoint(x: rulerWidth - length, y: y))
         case .left:
             return (CGPoint(x: 1, y: y), CGPoint(x: length, y: y))
-        case .top, .bottom:
-            assertionFailure("Vertical ruler ticks must be placed on a vertical side")
-            return (CGPoint(x: rulerWidth - 1, y: y), CGPoint(x: rulerWidth - length, y: y))
         }
     }
 
@@ -245,7 +242,7 @@ class VerticalRule: RuleView {
         forY y: CGFloat,
         labelSize: NSSize,
         rulerWidth: CGFloat,
-        tickSide: RulerSide
+        tickSide: RulerHorizontalSide
     ) -> CGRect {
         let labelOffset: CGFloat = 13
         let textHeight: CGFloat = 8
@@ -256,9 +253,6 @@ class VerticalRule: RuleView {
             labelX = rulerWidth - labelSize.width - labelOffset
         case .left:
             labelX = labelOffset
-        case .top, .bottom:
-            assertionFailure("Vertical ruler labels must be placed on a vertical side")
-            labelX = rulerWidth - labelSize.width - labelOffset
         }
 
         return CGRect(

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -67,10 +67,10 @@ final class RulerCoreTests: XCTestCase {
                 zeroCorner: ZeroCorner,
                 horizontalGrowth: RulerGrowthDirection,
                 verticalGrowth: RulerGrowthDirection,
-                horizontalTickSide: RulerSide,
-                verticalTickSide: RulerSide,
-                horizontalResizeSide: RulerSide,
-                verticalResizeSide: RulerSide
+                horizontalTickSide: RulerVerticalSide,
+                verticalTickSide: RulerHorizontalSide,
+                horizontalResizeSide: RulerHorizontalSide,
+                verticalResizeSide: RulerVerticalSide
             )
         ] = [
             (.topLeft, .positive, .negative, .bottom, .right, .right, .bottom),
@@ -93,24 +93,85 @@ final class RulerCoreTests: XCTestCase {
                 "\(testCase.zeroCorner) vertical growth"
             )
             XCTAssertEqual(
-                geometry.tickSide(for: .horizontal),
+                geometry.horizontalTickSide,
                 testCase.horizontalTickSide,
                 "\(testCase.zeroCorner) horizontal tick side"
             )
             XCTAssertEqual(
-                geometry.tickSide(for: .vertical),
+                geometry.verticalTickSide,
                 testCase.verticalTickSide,
                 "\(testCase.zeroCorner) vertical tick side"
             )
             XCTAssertEqual(
-                geometry.resizeSide(for: .horizontal),
+                geometry.horizontalResizeSide,
                 testCase.horizontalResizeSide,
                 "\(testCase.zeroCorner) horizontal resize side"
             )
             XCTAssertEqual(
-                geometry.resizeSide(for: .vertical),
+                geometry.verticalResizeSide,
                 testCase.verticalResizeSide,
                 "\(testCase.zeroCorner) vertical resize side"
+            )
+        }
+    }
+
+    func testZeroCornerGeometryDerivesAxisSpecificCornerPlacements() {
+        let cases: [
+            (
+                zeroCorner: ZeroCorner,
+                unitLabelPlacement: RulerCornerPlacement,
+                horizontalResizePlacement: RulerCornerPlacement,
+                verticalResizePlacement: RulerCornerPlacement
+            )
+        ] = [
+            (
+                .topLeft,
+                RulerCornerPlacement(xSide: .left, ySide: .top),
+                RulerCornerPlacement(xSide: .right, ySide: .top),
+                RulerCornerPlacement(xSide: .left, ySide: .bottom)
+            ),
+            (
+                .topRight,
+                RulerCornerPlacement(xSide: .right, ySide: .top),
+                RulerCornerPlacement(xSide: .left, ySide: .top),
+                RulerCornerPlacement(xSide: .right, ySide: .bottom)
+            ),
+            (
+                .bottomLeft,
+                RulerCornerPlacement(xSide: .left, ySide: .bottom),
+                RulerCornerPlacement(xSide: .right, ySide: .bottom),
+                RulerCornerPlacement(xSide: .left, ySide: .top)
+            ),
+            (
+                .bottomRight,
+                RulerCornerPlacement(xSide: .right, ySide: .bottom),
+                RulerCornerPlacement(xSide: .left, ySide: .bottom),
+                RulerCornerPlacement(xSide: .right, ySide: .top)
+            ),
+        ]
+
+        for testCase in cases {
+            let geometry = ZeroCornerGeometry(zeroCorner: testCase.zeroCorner)
+
+            XCTAssertEqual(
+                geometry.unitLabelPlacement(for: .horizontal),
+                testCase.unitLabelPlacement,
+                "\(testCase.zeroCorner) horizontal unit label placement"
+            )
+            XCTAssertEqual(
+                geometry.unitLabelPlacement(for: .vertical),
+                testCase.unitLabelPlacement,
+                "\(testCase.zeroCorner) vertical unit label placement"
+            )
+            XCTAssertEqual(
+                geometry.resizeHandlePlacement(for: .horizontal),
+                testCase.horizontalResizePlacement,
+                "\(testCase.zeroCorner) horizontal resize handle placement"
+            )
+            XCTAssertEqual(
+                geometry.resizeHandlePlacement(for: .vertical),
+                testCase.verticalResizePlacement,
+                "\(testCase.zeroCorner) vertical resize handle placement"
             )
         }
     }
@@ -1138,10 +1199,10 @@ final class RulerCoreTests: XCTestCase {
             let cases: [
                 (
                     zeroCorner: ZeroCorner,
-                    expectedHorizontalXSide: RulerSide,
-                    expectedHorizontalYSide: RulerSide,
-                    expectedVerticalXSide: RulerSide,
-                    expectedVerticalYSide: RulerSide
+                    expectedHorizontalXSide: RulerHorizontalSide,
+                    expectedHorizontalYSide: RulerVerticalSide,
+                    expectedVerticalXSide: RulerHorizontalSide,
+                    expectedVerticalYSide: RulerVerticalSide
                 )
             ] = [
                 (.topLeft, .right, .top, .left, .bottom),
@@ -1170,8 +1231,6 @@ final class RulerCoreTests: XCTestCase {
                     XCTAssertLessThan(horizontalFrame.midX, horizontalRule.bounds.midX, "\(testCase.zeroCorner)")
                 case .right:
                     XCTAssertGreaterThan(horizontalFrame.midX, horizontalRule.bounds.midX, "\(testCase.zeroCorner)")
-                case .top, .bottom:
-                    XCTFail("Horizontal resize handle X must be placed on a horizontal side")
                 }
 
                 switch testCase.expectedHorizontalYSide {
@@ -1179,8 +1238,6 @@ final class RulerCoreTests: XCTestCase {
                     XCTAssertGreaterThan(horizontalFrame.midY, horizontalRule.bounds.midY, "\(testCase.zeroCorner)")
                 case .bottom:
                     XCTAssertLessThan(horizontalFrame.midY, horizontalRule.bounds.midY, "\(testCase.zeroCorner)")
-                case .left, .right:
-                    XCTFail("Horizontal resize handle Y must be placed on a vertical side")
                 }
 
                 switch testCase.expectedVerticalXSide {
@@ -1188,8 +1245,6 @@ final class RulerCoreTests: XCTestCase {
                     XCTAssertLessThan(verticalFrame.midX, verticalRule.bounds.midX, "\(testCase.zeroCorner)")
                 case .right:
                     XCTAssertGreaterThan(verticalFrame.midX, verticalRule.bounds.midX, "\(testCase.zeroCorner)")
-                case .top, .bottom:
-                    XCTFail("Vertical resize handle X must be placed on a horizontal side")
                 }
 
                 switch testCase.expectedVerticalYSide {
@@ -1197,8 +1252,6 @@ final class RulerCoreTests: XCTestCase {
                     XCTAssertGreaterThan(verticalFrame.midY, verticalRule.bounds.midY, "\(testCase.zeroCorner)")
                 case .bottom:
                     XCTAssertLessThan(verticalFrame.midY, verticalRule.bounds.midY, "\(testCase.zeroCorner)")
-                case .left, .right:
-                    XCTFail("Vertical resize handle Y must be placed on a vertical side")
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Replace the broad ruler side model with axis-specific horizontal and vertical side types.
- Expose typed zero-corner geometry properties for tick, resize, and corner placement decisions.
- Remove defensive assertion fallback branches that represented impossible axis combinations.
- Add focused unit coverage for the typed geometry outputs.

Fixes #209

## Validation

- `xcodebuild -project 'Free Ruler.xcodeproj' -scheme 'Free Ruler' test -only-testing:FreeRulerTests`
- `git diff --check`