### PR TITLE
Persist and restore multiple rulers

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -79,6 +79,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 settingsController.close()
             }
         }
+        manager.onStateChanged = { [weak self] _ in
+            self?.saveRulerSetState()
+        }
         return manager
     }()
 
@@ -185,6 +188,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         configureUpdater()
 #endif
 
+        restoreSavedRulers()
         showRulers()
     }
 
@@ -398,6 +402,55 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         createRulersIfNeeded()
         rulerManager.showAll()
         updateMouseTickTimer()
+    }
+
+    func restoreSavedRulers() {
+        if let restoredState = prefs.loadRulerSetState() {
+            rulerManager.restore(
+                restoredState.rulers,
+                activeRulerID: restoredState.activeRulerID
+            )
+            return
+        }
+
+        if let migratedState = migratedLegacyRulerState() {
+            rulerManager.restore([migratedState], activeRulerID: migratedState.id)
+        }
+    }
+
+    private func saveRulerSetState() {
+        prefs.saveRulerSetState(
+            rulers: rulerManager.states,
+            activeRulerID: rulerManager.activeRulerID
+        )
+    }
+
+    private func migratedLegacyRulerState() -> RulerInstanceState? {
+        let defaults = UserDefaults.standard
+        let horizontalAutosaveName = "horizontal-ruler"
+        let verticalAutosaveName = "vertical-ruler"
+        let hasLegacyAutosave = defaults.object(forKey: "NSWindow Frame \(horizontalAutosaveName)") != nil
+            || defaults.object(forKey: "NSWindow Frame \(verticalAutosaveName)") != nil
+        guard hasLegacyAutosave else { return nil }
+
+        let settings = RulerSettings(defaults: prefs)
+        let horizontalWindow = RulerWindow(
+            ruler: Ruler(.horizontal, name: horizontalAutosaveName)
+        )
+        let verticalWindow = RulerWindow(
+            ruler: Ruler(.vertical, name: verticalAutosaveName)
+        )
+        _ = horizontalWindow.setFrameUsingName(NSWindow.FrameAutosaveName(horizontalAutosaveName))
+        _ = verticalWindow.setFrameUsingName(NSWindow.FrameAutosaveName(verticalAutosaveName))
+
+        return RulerInstanceState(
+            settings: settings,
+            layout: RulerLayoutState(
+                horizontalFrame: horizontalWindow.frame,
+                verticalFrame: verticalWindow.frame,
+                zeroCorner: settings.zeroCorner
+            )
+        )
     }
 
     func toggleRuler(orientation: Orientation) {
@@ -1046,6 +1099,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ aNotification: Notification) {
         closeRulerColorPanel()
+        saveRulerSetState()
         prefs.save()
     }
 

--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -844,12 +844,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBAction func resetRulerPositions(_ sender: Any) {
         if let controller = rulerManager.activeController {
-            controller.state.settings.zeroCorner = Prefs.defaultZeroCorner
-            controller.state.layout = RulerLayoutState.defaults(
-                zeroCorner: Prefs.defaultZeroCorner
-            )
-            controller.state.visibility = RulerWingVisibility()
-            controller.show()
+            controller.resetPosition()
             updateDisplay()
             updateMouseTickTimer()
             return

--- a/Free Ruler/GroupedRulerWindow.swift
+++ b/Free Ruler/GroupedRulerWindow.swift
@@ -1612,6 +1612,7 @@ final class RulerManager {
     private(set) var controllers: [GroupedRulerController] = []
     private(set) var activeRulerID: UUID?
     var onActiveControllerChanged: ((GroupedRulerController?) -> Void)?
+    var onStateChanged: ((RulerManager) -> Void)?
 
     init(
         initialStates: [RulerInstanceState] = [],
@@ -1668,7 +1669,7 @@ final class RulerManager {
         return controller
     }
 
-    func restore(_ states: [RulerInstanceState]) {
+    func restore(_ states: [RulerInstanceState], activeRulerID restoredActiveRulerID: UUID? = nil) {
         for controller in controllers {
             controller.hide()
         }
@@ -1680,6 +1681,13 @@ final class RulerManager {
         for state in states where state.hasVisibleWing {
             addRuler(state: state)
         }
+
+        if let restoredActiveRulerID = restoredActiveRulerID,
+           let restoredActiveController = controller(id: restoredActiveRulerID) {
+            markActive(restoredActiveController)
+        }
+
+        notifyStateChanged()
     }
 
     func showAll() {
@@ -1708,6 +1716,8 @@ final class RulerManager {
             activeRulerID = controllers.last?.state.id
             onActiveControllerChanged?(activeController)
         }
+
+        notifyStateChanged()
     }
 
     func markActive(_ controller: GroupedRulerController) {
@@ -1715,12 +1725,17 @@ final class RulerManager {
 
         activeRulerID = controller.state.id
         onActiveControllerChanged?(controller)
+        notifyStateChanged()
     }
 
     func controller(containing window: NSWindow?) -> GroupedRulerController? {
         guard let window = window else { return nil }
 
         return controllers.first { $0.groupedWindow === window }
+    }
+
+    func controller(id: UUID) -> GroupedRulerController? {
+        return controllers.first { $0.state.id == id }
     }
 
     private func configure(_ controller: GroupedRulerController) {
@@ -1733,7 +1748,12 @@ final class RulerManager {
                   self?.activeRulerID == controller.state.id else { return }
 
             self?.activeRulerID = controller.state.id
+            self?.notifyStateChanged()
         }
+    }
+
+    private func notifyStateChanged() {
+        onStateChanged?(self)
     }
 }
 #endif

--- a/Free Ruler/GroupedRulerWindow.swift
+++ b/Free Ruler/GroupedRulerWindow.swift
@@ -1292,6 +1292,16 @@ final class GroupedRulerController: NSWindowController, NSWindowDelegate, Notifi
         notifyStateChanged()
     }
 
+    func resetPosition() {
+        state.settings.zeroCorner = Prefs.defaultZeroCorner
+        state.layout = RulerLayoutState.defaults(
+            zeroCorner: Prefs.defaultZeroCorner
+        )
+        state.visibility = RulerWingVisibility()
+        show()
+        notifyStateChanged()
+    }
+
     func drawMouseTick(at mouseLoc: NSPoint) {
         if groupedWindow.isRuleVisible(.horizontal) {
             groupedWindow.horizontalRule.drawMouseTick(at: mouseLoc)

--- a/Free Ruler/Prefs.swift
+++ b/Free Ruler/Prefs.swift
@@ -129,6 +129,8 @@ class Prefs: NSObject {
 }
 
 extension Prefs {
+    static let rulerSetStateKey = "rulerSetState"
+
     static var defaultZeroCorner: ZeroCorner {
         return .topLeft
     }
@@ -188,5 +190,39 @@ extension Prefs {
             ofClass: NSColor.self,
             from: data
         )
+    }
+
+    func saveRulerSetState(rulers: [RulerInstanceState], activeRulerID: UUID?) {
+        let visibleRulers = rulers.filter(\.hasVisibleWing)
+        guard !visibleRulers.isEmpty else {
+            clearRulerSetState()
+            return
+        }
+
+        let activeRulerIDToSave = activeRulerID.flatMap { activeRulerID in
+            visibleRulers.contains { $0.id == activeRulerID } ? activeRulerID : nil
+        }
+        let state = StoredRulerSetState(
+            rulers: visibleRulers,
+            activeRulerID: activeRulerIDToSave
+        )
+
+        guard let data = try? JSONEncoder().encode(state) else { return }
+
+        UserDefaults.standard.set(data, forKey: Self.rulerSetStateKey)
+    }
+
+    func loadRulerSetState() -> StoredRulerSetState? {
+        guard let data = UserDefaults.standard.data(forKey: Self.rulerSetStateKey),
+              let state = try? JSONDecoder().decode(StoredRulerSetState.self, from: data),
+              state.schemaVersion == StoredRulerSetState.currentSchemaVersion else {
+            return nil
+        }
+
+        return state.sanitizedForRestore()
+    }
+
+    func clearRulerSetState() {
+        UserDefaults.standard.removeObject(forKey: Self.rulerSetStateKey)
     }
 }

--- a/Free Ruler/Ruler.swift
+++ b/Free Ruler/Ruler.swift
@@ -377,6 +377,39 @@ struct RulerInstanceState: Identifiable, Equatable, Codable {
     }
 }
 
+struct StoredRulerSetState: Equatable, Codable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var rulers: [RulerInstanceState]
+    var activeRulerID: UUID?
+
+    init(
+        schemaVersion: Int = StoredRulerSetState.currentSchemaVersion,
+        rulers: [RulerInstanceState],
+        activeRulerID: UUID?
+    ) {
+        self.schemaVersion = schemaVersion
+        self.rulers = rulers
+        self.activeRulerID = activeRulerID
+    }
+
+    func sanitizedForRestore() -> StoredRulerSetState? {
+        let visibleRulers = rulers.filter(\.hasVisibleWing)
+        guard !visibleRulers.isEmpty else { return nil }
+
+        let restoredActiveRulerID = activeRulerID.flatMap { activeRulerID in
+            visibleRulers.contains { $0.id == activeRulerID } ? activeRulerID : nil
+        }
+
+        return StoredRulerSetState(
+            schemaVersion: schemaVersion,
+            rulers: visibleRulers,
+            activeRulerID: restoredActiveRulerID
+        )
+    }
+}
+
 struct RulerCornerPlacement: Equatable {
     let xSide: RulerHorizontalSide
     let ySide: RulerVerticalSide

--- a/Free Ruler/UITestSupport+App.swift
+++ b/Free Ruler/UITestSupport+App.swift
@@ -12,6 +12,7 @@ extension UITestSupport {
             "rulerColor",
             "unit",
             "zeroCorner",
+            Prefs.rulerSetStateKey,
             "NSWindow Frame horizontal-ruler",
             "NSWindow Frame vertical-ruler",
             "NSWindow Frame preferencesWindow",

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -2691,35 +2691,44 @@ final class RulerCoreTests: XCTestCase {
 
     func testManagedFlipAndResetUseActiveRulerWithoutChangingDefaults() {
         withRestoredRulerPreferences {
-            prefs.zeroCorner = .topRight
-            let appDelegate = AppDelegate()
-            let first = appDelegate.rulerManager.createRuler(
-                defaults: RulerSettings(zeroCorner: .bottomLeft)
-            )
-            let second = appDelegate.rulerManager.createRuler(
-                defaults: RulerSettings(zeroCorner: .topLeft)
-            )
-            defer {
-                first.hide()
-                second.hide()
+            withRestoredRulerSetState {
+                prefs.zeroCorner = .topRight
+                let appDelegate = AppDelegate()
+                let first = appDelegate.rulerManager.createRuler(
+                    defaults: RulerSettings(zeroCorner: .bottomLeft)
+                )
+                let second = appDelegate.rulerManager.createRuler(
+                    defaults: RulerSettings(zeroCorner: .topLeft)
+                )
+                defer {
+                    first.hide()
+                    second.hide()
+                }
+
+                second.setWing(.vertical, isVisible: false)
+                appDelegate.rulerManager.markActive(second)
+                appDelegate.flipRulers(along: .horizontal)
+
+                XCTAssertEqual(second.state.settings.zeroCorner, .topRight)
+                XCTAssertEqual(second.groupedWindow.horizontalRule.zeroCorner, .topRight)
+                XCTAssertEqual(first.state.settings.zeroCorner, .bottomLeft)
+                XCTAssertEqual(prefs.zeroCorner, .topRight)
+
+                appDelegate.resetRulerPositions(self)
+
+                XCTAssertEqual(second.state.settings.zeroCorner, Prefs.defaultZeroCorner)
+                XCTAssertTrue(second.state.isWingVisible(.horizontal))
+                XCTAssertTrue(second.state.isWingVisible(.vertical))
+                XCTAssertEqual(first.state.settings.zeroCorner, .bottomLeft)
+                XCTAssertEqual(prefs.zeroCorner, .topRight)
+
+                let restoredState = prefs.loadRulerSetState()
+                let savedSecond = restoredState?.rulers.first { $0.id == second.state.id }
+                XCTAssertEqual(restoredState?.activeRulerID, second.state.id)
+                XCTAssertEqual(savedSecond?.settings.zeroCorner, Prefs.defaultZeroCorner)
+                XCTAssertTrue(savedSecond?.visibility.showsHorizontal ?? false)
+                XCTAssertTrue(savedSecond?.visibility.showsVertical ?? false)
             }
-
-            second.setWing(.vertical, isVisible: false)
-            appDelegate.rulerManager.markActive(second)
-            appDelegate.flipRulers(along: .horizontal)
-
-            XCTAssertEqual(second.state.settings.zeroCorner, .topRight)
-            XCTAssertEqual(second.groupedWindow.horizontalRule.zeroCorner, .topRight)
-            XCTAssertEqual(first.state.settings.zeroCorner, .bottomLeft)
-            XCTAssertEqual(prefs.zeroCorner, .topRight)
-
-            appDelegate.resetRulerPositions(self)
-
-            XCTAssertEqual(second.state.settings.zeroCorner, Prefs.defaultZeroCorner)
-            XCTAssertTrue(second.state.isWingVisible(.horizontal))
-            XCTAssertTrue(second.state.isWingVisible(.vertical))
-            XCTAssertEqual(first.state.settings.zeroCorner, .bottomLeft)
-            XCTAssertEqual(prefs.zeroCorner, .topRight)
         }
     }
 

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -511,6 +511,145 @@ final class RulerCoreTests: XCTestCase {
         }
     }
 
+    func testSavedRulerSetStateRoundTripsThroughUserDefaults() {
+        withRestoredRulerSetState {
+            let firstID = UUID(uuidString: "8B425683-3E8E-4B2C-9F79-1B39FC70622D")!
+            let secondID = UUID(uuidString: "6B688B39-FC3E-454C-94C8-E77B3131F600")!
+            let states = [
+                RulerInstanceState(
+                    id: firstID,
+                    settings: RulerSettings(unit: .pixels),
+                    visibility: RulerWingVisibility(horizontal: true, vertical: false),
+                    layout: RulerLayoutState(
+                        zeroPoint: NSPoint(x: 200, y: 300),
+                        horizontalLength: 320,
+                        verticalLength: 180
+                    )
+                ),
+                RulerInstanceState(
+                    id: secondID,
+                    settings: RulerSettings(unit: .inches),
+                    visibility: RulerWingVisibility(horizontal: false, vertical: true),
+                    layout: RulerLayoutState(
+                        zeroPoint: NSPoint(x: 400, y: 500),
+                        horizontalLength: 220,
+                        verticalLength: 280
+                    )
+                ),
+            ]
+
+            prefs.saveRulerSetState(rulers: states, activeRulerID: secondID)
+            let restoredState = prefs.loadRulerSetState()
+
+            XCTAssertEqual(restoredState?.schemaVersion, StoredRulerSetState.currentSchemaVersion)
+            XCTAssertEqual(restoredState?.rulers, states)
+            XCTAssertEqual(restoredState?.activeRulerID, secondID)
+        }
+    }
+
+    func testSavedRulerSetStateFallsBackForCorruptOrUnknownSchemaData() throws {
+        try withRestoredRulerSetState {
+            UserDefaults.standard.set(Data("not-json".utf8), forKey: Prefs.rulerSetStateKey)
+
+            XCTAssertNil(prefs.loadRulerSetState())
+
+            let unknownSchemaState = StoredRulerSetState(
+                schemaVersion: StoredRulerSetState.currentSchemaVersion + 1,
+                rulers: [
+                    RulerInstanceState.createFromDefaults()
+                ],
+                activeRulerID: nil
+            )
+            let data = try JSONEncoder().encode(unknownSchemaState)
+            UserDefaults.standard.set(data, forKey: Prefs.rulerSetStateKey)
+
+            XCTAssertNil(prefs.loadRulerSetState())
+        }
+    }
+
+    func testRulerManagerRestoresSavedActiveRulerID() {
+        let firstID = UUID(uuidString: "CE2FB5D8-109F-4482-8F54-1381075EE8C8")!
+        let secondID = UUID(uuidString: "3BF78AE6-446F-4C43-82B4-F7D0CFEDDE83")!
+        let manager = RulerManager()
+        defer {
+            for controller in manager.controllers {
+                controller.hide()
+            }
+        }
+
+        manager.restore(
+            [
+                RulerInstanceState(
+                    id: firstID,
+                    settings: RulerSettings(unit: .pixels),
+                    layout: RulerLayoutState(
+                        zeroPoint: NSPoint(x: 200, y: 300),
+                        horizontalLength: 320,
+                        verticalLength: 180
+                    )
+                ),
+                RulerInstanceState(
+                    id: secondID,
+                    settings: RulerSettings(unit: .millimeters),
+                    layout: RulerLayoutState(
+                        zeroPoint: NSPoint(x: 400, y: 500),
+                        horizontalLength: 220,
+                        verticalLength: 280
+                    )
+                ),
+            ],
+            activeRulerID: firstID
+        )
+
+        XCTAssertEqual(manager.activeController?.state.id, firstID)
+    }
+
+    func testAppDelegateRestoresSavedRulerSetBeforeShowingDefaults() {
+        withRestoredRulerSetState {
+            let id = UUID(uuidString: "2D1A252A-E2AA-4BB8-9142-80F87802CFA3")!
+            let state = RulerInstanceState(
+                id: id,
+                settings: RulerSettings(unit: .inches, zeroCorner: .bottomRight),
+                visibility: RulerWingVisibility(horizontal: false, vertical: true),
+                layout: RulerLayoutState(
+                    zeroPoint: NSPoint(x: 500, y: 600),
+                    horizontalLength: 320,
+                    verticalLength: 240
+                )
+            )
+            prefs.saveRulerSetState(rulers: [state], activeRulerID: id)
+            let appDelegate = AppDelegate()
+            defer {
+                for controller in appDelegate.rulerManager.controllers {
+                    controller.hide()
+                }
+            }
+
+            appDelegate.restoreSavedRulers()
+
+            XCTAssertEqual(appDelegate.rulerManager.controllers.map(\.state.id), [id])
+            XCTAssertEqual(appDelegate.rulerManager.activeController?.state.id, id)
+            XCTAssertEqual(appDelegate.rulerManager.activeController?.state.settings.unit, .inches)
+            XCTAssertFalse(appDelegate.rulerManager.activeController?.state.isWingVisible(.horizontal) ?? true)
+            XCTAssertTrue(appDelegate.rulerManager.activeController?.state.isWingVisible(.vertical) ?? false)
+        }
+    }
+
+    func testUITestResetClearsSavedRulerSetState() {
+        withRestoredRulerPreferences {
+            withRestoredRulerSetState {
+                prefs.saveRulerSetState(
+                    rulers: [RulerInstanceState.createFromDefaults()],
+                    activeRulerID: nil
+                )
+
+                UITestSupport.prepareForLaunch().resetApplicationState()
+
+                XCTAssertNil(UserDefaults.standard.data(forKey: Prefs.rulerSetStateKey))
+            }
+        }
+    }
+
     func testZeroCornerRawValuesPreservePersistedOrder() {
         XCTAssertEqual(ZeroCorner.topLeft.rawValue, 0)
         XCTAssertEqual(ZeroCorner.topRight.rawValue, 1)
@@ -2944,6 +3083,21 @@ final class RulerCoreTests: XCTestCase {
             prefs.floatRulers = previousFloatRulers
             prefs.rulerShadow = previousRulerShadow
             prefs.zeroCorner = previousZeroCorner
+        }
+
+        try test()
+    }
+
+    private func withRestoredRulerSetState(_ test: () throws -> Void) rethrows {
+        let defaults = UserDefaults.standard
+        let previousState = defaults.object(forKey: Prefs.rulerSetStateKey)
+
+        defer {
+            if let previousState = previousState {
+                defaults.set(previousState, forKey: Prefs.rulerSetStateKey)
+            } else {
+                defaults.removeObject(forKey: Prefs.rulerSetStateKey)
+            }
         }
 
         try test()


### PR DESCRIPTION
Implements #234 as part of #228. Adds a schema-versioned UserDefaults ruler-set store, restores saved rulers and active selection on launch, falls back for corrupt data, clears state for UI tests, and migrates old autosaved ruler frames when possible.