### PR TITLE
Add ruler cycling command

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -794,6 +794,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateMouseTickTimer()
     }
 
+    @IBAction func cycleRulers(_ sender: Any) {
+        guard rulerManager.cycleActiveRuler() != nil else { return }
+
+        updateDisplay()
+    }
+
     @IBAction func closeKeyWindow(_ sender: Any) {
         if let controller = rulerManager.controller(containing: NSApp.keyWindow) {
             rulerManager.close(controller)
@@ -870,10 +876,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         prefs.groupRulers = Prefs.defaultGroupRulers
         applyRulerWindowMode()
-    }
-
-    @IBAction func showRulers(_ sender: Any) {
-        showRulers()
     }
 
     @IBAction func toggleHorizontalRuler(_ sender: Any) {
@@ -1019,6 +1021,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return true
         }
 
+        if keyboardModifiers == .command {
+            switch keyCode {
+            case kVK_ANSI_Grave:
+                cycleRulers(sender)
+            default:
+                return false
+            }
+
+            return true
+        }
+
         guard keyboardModifiers.isEmpty else { return false }
 
         switch keyCode {
@@ -1145,9 +1158,6 @@ extension AppDelegate: NSMenuItemValidation {
                 ? NSLocalizedString("Hide Vertical Ruler", comment: "Menu item title to hide the vertical ruler")
                 : NSLocalizedString("Show Vertical Ruler", comment: "Menu item title to show the vertical ruler")
             return canToggleRulerVisibility
-        case #selector(showRulers(_:)):
-            menuItem.title = NSLocalizedString("Show All Rulers", comment: "Menu item title to show all ruler windows")
-            return true
         default:
             return true
         }

--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -98,12 +98,6 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="mwO-GY-nrW"/>
-                            <menuItem title="Show All Rulers" id="qVa-aF-DQ8">
-                                <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="showRulers:" target="Voe-Tx-rLC" id="NLA-hk-Wbc"/>
-                                </connections>
-                            </menuItem>
                             <menuItem title="Ruler Settings…" keyEquivalent="," id="rSt-Tg-232">
                                 <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>

--- a/Free Ruler/GroupedRulerWindow.swift
+++ b/Free Ruler/GroupedRulerWindow.swift
@@ -1761,6 +1761,24 @@ final class RulerManager {
     }
 
     @discardableResult
+    func cycleActiveRuler() -> GroupedRulerController? {
+        let visibleControllers = controllers.filter(\.isVisible)
+        guard !visibleControllers.isEmpty else { return nil }
+
+        let activeID = activeController?.state.id
+        let activeIndex = activeID.flatMap { activeID in
+            visibleControllers.firstIndex { $0.state.id == activeID }
+        }
+        let nextIndex = activeIndex.map { ($0 + 1) % visibleControllers.count } ?? 0
+        let nextController = visibleControllers[nextIndex]
+
+        markActive(nextController)
+        nextController.groupedWindow.orderFrontRegardless()
+        nextController.groupedWindow.makeKey()
+        return nextController
+    }
+
+    @discardableResult
     func closeActiveRuler() -> Bool {
         guard let activeController = activeController else { return false }
 

--- a/Free Ruler/Localizable.xcstrings
+++ b/Free Ruler/Localizable.xcstrings
@@ -887,48 +887,6 @@
         }
       }
     },
-    "Show All Rulers" : {
-      "comment" : "Menu item title to show all ruler windows",
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Lineale anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show All Rulers"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar todas las reglas"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Näytä kaikki viivaimet"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべての定規を表示"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示所有标尺"
-          }
-        }
-      }
-    },
     "Show Horizontal Ruler" : {
       "comment" : "Menu item title to show the horizontal ruler",
       "extractionState" : "manual",

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -240,6 +240,27 @@ final class RulerCoreTests: XCTestCase {
         }
     }
 
+    func testRulerManagerCyclesVisibleRulers() {
+        let manager = RulerManager()
+        let first = manager.createRuler()
+        let second = manager.createRuler()
+        let hidden = manager.createRuler()
+        defer {
+            first.hide()
+            second.hide()
+            hidden.hide()
+        }
+        first.show()
+        second.show()
+        manager.markActive(first)
+
+        XCTAssertTrue(manager.cycleActiveRuler() === second)
+        XCTAssertTrue(manager.activeController === second)
+
+        XCTAssertTrue(manager.cycleActiveRuler() === first)
+        XCTAssertTrue(manager.activeController === first)
+    }
+
     func testRulerContextMenuActivatesClickedRulerAndShowsSettingsCommand() {
         withInstalledAppDelegate { appDelegate in
             let manager = appDelegate.rulerManager
@@ -3410,6 +3431,29 @@ final class RulerCoreTests: XCTestCase {
             )
             XCTAssertFalse(prefs.groupRulers)
         }
+    }
+
+    func testCommandGraveCyclesManagedRulers() {
+        let appDelegate = AppDelegate()
+        let first = appDelegate.rulerManager.createRuler()
+        let second = appDelegate.rulerManager.createRuler()
+        defer {
+            first.hide()
+            second.hide()
+        }
+        first.show()
+        second.show()
+        appDelegate.rulerManager.markActive(first)
+
+        XCTAssertTrue(
+            appDelegate.performRulerHotkey(
+                keyCode: kVK_ANSI_Grave,
+                modifierFlags: .command,
+                sender: first
+            )
+        )
+
+        XCTAssertTrue(appDelegate.rulerManager.activeController === second)
     }
 
     func testManagedWingHotkeysAffectOnlyActiveRuler() {


### PR DESCRIPTION
## Summary
- Adds the standard Command-Grave shortcut for cycling the active ruler window.
- Tracks active ruler state so cycling moves through visible rulers predictably.
- Removes the old Show All Rulers command from the Ruler menu.

## Tests
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests`

Closes #249