### PR TITLE
Swap settings shortcuts

### DIFF
--- a/Free Ruler/Base.lproj/MainMenu.xib
+++ b/Free Ruler/Base.lproj/MainMenu.xib
@@ -38,7 +38,8 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                            <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
+                            <menuItem title="Settings…" keyEquivalent="," id="BOF-NM-1cW">
+                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="openPreferences:" target="Voe-Tx-rLC" id="aUA-em-iuQ"/>
                                 </connections>
@@ -99,7 +100,6 @@
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="mwO-GY-nrW"/>
                             <menuItem title="Ruler Settings…" keyEquivalent="," id="rSt-Tg-232">
-                                <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                 <connections>
                                     <action selector="openRulerSettings:" target="Voe-Tx-rLC" id="RSa-Tg-232"/>
                                 </connections>

--- a/Free Ruler/Base.lproj/PreferencesController.xib
+++ b/Free Ruler/Base.lproj/PreferencesController.xib
@@ -15,7 +15,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Free Ruler Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="preferencesWindow" animationBehavior="default" id="F0z-JX-Cv5">
+        <window title="Free Ruler Settings" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" frameAutosaveName="preferencesWindow" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="602" y="400" width="360" height="426"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1512" height="944"/>

--- a/Free Ruler/de.lproj/MainMenu.strings
+++ b/Free Ruler/de.lproj/MainMenu.strings
@@ -26,7 +26,7 @@
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
 
-/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
+/* Class = "NSMenuItem"; title = "Settings…"; ObjectID = "BOF-NM-1cW"; */
 "BOF-NM-1cW.title" = "Einstellungen …";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */

--- a/Free Ruler/de.lproj/PreferencesController.strings
+++ b/Free Ruler/de.lproj/PreferencesController.strings
@@ -1,5 +1,5 @@
 
-/* Class = "NSWindow"; title = "Free Ruler Preferences"; ObjectID = "F0z-JX-Cv5"; */
+/* Class = "NSWindow"; title = "Free Ruler Settings"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "„Free Ruler“-Einstellungen";
 
 /* Class = "NSTextFieldCell"; title = "Default settings for new rulers"; ObjectID = "PREF-defaults-header-cell"; */

--- a/Free Ruler/es.lproj/MainMenu.strings
+++ b/Free Ruler/es.lproj/MainMenu.strings
@@ -29,8 +29,8 @@
 /* Class = "NSMenuItem"; title = "Millimeters"; ObjectID = "B6Y-Hi-AkN"; */
 "B6Y-Hi-AkN.title" = "Milímetros";
 
-/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "Preferencias…";
+/* Class = "NSMenuItem"; title = "Settings…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "Ajustes…";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
 "DVo-aG-piG.title" = "Cerrar";

--- a/Free Ruler/es.lproj/PreferencesController.strings
+++ b/Free Ruler/es.lproj/PreferencesController.strings
@@ -1,6 +1,6 @@
 
-/* Class = "NSWindow"; title = "Free Ruler Preferences"; ObjectID = "F0z-JX-Cv5"; */
-"F0z-JX-Cv5.title" = "Preferencias de Free Ruler";
+/* Class = "NSWindow"; title = "Free Ruler Settings"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Ajustes de Free Ruler";
 
 /* Class = "NSTextFieldCell"; title = "Default settings for new rulers"; ObjectID = "PREF-defaults-header-cell"; */
 "PREF-defaults-header-cell.title" = "Ajustes predeterminados para reglas nuevas";

--- a/Free Ruler/fi.lproj/MainMenu.strings
+++ b/Free Ruler/fi.lproj/MainMenu.strings
@@ -26,7 +26,7 @@
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Päävalikko";
 
-/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
+/* Class = "NSMenuItem"; title = "Settings…"; ObjectID = "BOF-NM-1cW"; */
 "BOF-NM-1cW.title" = "Asetukset…";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */

--- a/Free Ruler/fi.lproj/PreferencesController.strings
+++ b/Free Ruler/fi.lproj/PreferencesController.strings
@@ -1,5 +1,5 @@
 
-/* Class = "NSWindow"; title = "Free Ruler Preferences"; ObjectID = "F0z-JX-Cv5"; */
+/* Class = "NSWindow"; title = "Free Ruler Settings"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Free Rulerin asetukset";
 
 /* Class = "NSTextFieldCell"; title = "Default settings for new rulers"; ObjectID = "PREF-defaults-header-cell"; */

--- a/Free Ruler/ja.lproj/MainMenu.strings
+++ b/Free Ruler/ja.lproj/MainMenu.strings
@@ -29,8 +29,8 @@
 /* Class = "NSMenuItem"; title = "Millimeters"; ObjectID = "B6Y-Hi-AkN"; */
 "B6Y-Hi-AkN.title" = "ミリメートル";
 
-/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "環境設定...";
+/* Class = "NSMenuItem"; title = "Settings…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "設定...";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
 "DVo-aG-piG.title" = "閉じる";

--- a/Free Ruler/ja.lproj/PreferencesController.strings
+++ b/Free Ruler/ja.lproj/PreferencesController.strings
@@ -1,6 +1,6 @@
 
-/* Class = "NSWindow"; title = "Free Ruler Preferences"; ObjectID = "F0z-JX-Cv5"; */
-"F0z-JX-Cv5.title" = "Free Rulerの環境設定";
+/* Class = "NSWindow"; title = "Free Ruler Settings"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Free Rulerの設定";
 
 /* Class = "NSTextFieldCell"; title = "Default settings for new rulers"; ObjectID = "PREF-defaults-header-cell"; */
 "PREF-defaults-header-cell.title" = "新しい定規のデフォルト設定";

--- a/Free Ruler/zh-hans.lproj/MainMenu.strings
+++ b/Free Ruler/zh-hans.lproj/MainMenu.strings
@@ -26,8 +26,8 @@
 /* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
 "AYu-sK-qS6.title" = "Main Menu";
 
-/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "偏好设置…";
+/* Class = "NSMenuItem"; title = "Settings…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "设置…";
 
 /* Class = "NSMenuItem"; title = "Close"; ObjectID = "DVo-aG-piG"; */
 "DVo-aG-piG.title" = "关闭";

--- a/Free Ruler/zh-hans.lproj/PreferencesController.strings
+++ b/Free Ruler/zh-hans.lproj/PreferencesController.strings
@@ -1,6 +1,6 @@
 
-/* Class = "NSWindow"; title = "Free Ruler Preferences"; ObjectID = "F0z-JX-Cv5"; */
-"F0z-JX-Cv5.title" = "Free Ruler 偏好设置";
+/* Class = "NSWindow"; title = "Free Ruler Settings"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Free Ruler 设置";
 
 /* Class = "NSTextFieldCell"; title = "Default settings for new rulers"; ObjectID = "PREF-defaults-header-cell"; */
 "PREF-defaults-header-cell.title" = "新尺子的默认设置";


### PR DESCRIPTION
## Summary
- Swaps the keyboard shortcuts so Ruler Settings uses Command-Comma and app settings uses Command-Option-Comma.
- Updates the main settings window title to Free Ruler Settings.
- Keeps localized menu and window resources in sync with the shortcut/title changes.

## Tests
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests`

Closes #250