### PR TITLE
Disable inactive ruler wing menu commands

### DIFF
--- a/Free Ruler/AppDelegate.swift
+++ b/Free Ruler/AppDelegate.swift
@@ -769,7 +769,7 @@ extension AppDelegate: NSMenuItemValidation {
                 "Show Horizontal Ruler",
                 comment: "Menu item title to show the horizontal ruler"
             )
-            return true
+            return false
         case #selector(toggleVerticalRuler(_:)):
             if let controller = rulerManager.activeController {
                 let isVisible = controller.state.isWingVisible(.vertical)
@@ -783,7 +783,7 @@ extension AppDelegate: NSMenuItemValidation {
                 "Show Vertical Ruler",
                 comment: "Menu item title to show the vertical ruler"
             )
-            return true
+            return false
         default:
             return true
         }

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -3588,6 +3588,25 @@ final class RulerCoreTests: XCTestCase {
         XCTAssertTrue(appDelegate.validateMenuItem(groupItem))
     }
 
+    func testManagedMenuValidationDisablesWingCommandsWithoutActiveRuler() {
+        let appDelegate = AppDelegate()
+        let horizontalItem = NSMenuItem(
+            title: "",
+            action: #selector(AppDelegate.toggleHorizontalRuler(_:)),
+            keyEquivalent: ""
+        )
+        let verticalItem = NSMenuItem(
+            title: "",
+            action: #selector(AppDelegate.toggleVerticalRuler(_:)),
+            keyEquivalent: ""
+        )
+
+        XCTAssertFalse(appDelegate.validateMenuItem(horizontalItem))
+        XCTAssertEqual(horizontalItem.title, "Show Horizontal Ruler")
+        XCTAssertFalse(appDelegate.validateMenuItem(verticalItem))
+        XCTAssertEqual(verticalItem.title, "Show Vertical Ruler")
+    }
+
     func testShiftHotkeysFlipActiveRulerOrigin() {
         let appDelegate = AppDelegate()
         let controller = appDelegate.rulerManager.createRuler(


### PR DESCRIPTION
## Summary

Disables the Horizontal and Vertical ruler hide/show menu items when there is no active ruler, while keeping their fallback titles as "Show Horizontal Ruler" and "Show Vertical Ruler".

## Root Cause

The menu validator updated the fallback titles for the no-active-ruler case but still returned `true`, leaving both commands enabled even though there was no active ruler to affect.

## Validation

- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests/RulerCoreTests/testManagedMenuValidationDisablesWingCommandsWithoutActiveRuler`
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests`

Closes #266