### PR TITLE
Keep grouped active ruler topmost

### DIFF
--- a/Free Ruler/RulerWindow.swift
+++ b/Free Ruler/RulerWindow.swift
@@ -1765,6 +1765,9 @@ final class RulerManager {
         guard controllers.contains(where: { $0 === controller }) else { return }
 
         activeRulerID = controller.state.id
+        if prefs.groupRulers {
+            moveControllerToTopOfStack(controller)
+        }
         updateActiveRulerBorders()
         onActiveControllerChanged?(controller)
         notifyStateChanged()
@@ -1848,6 +1851,17 @@ final class RulerManager {
         syncGroupedDrag(from: controller)
         detachGroupedDragFollowers(from: controller, groupedDragState: groupedDragState)
         captureGroupedDragFollowerStates(excluding: controller, groupedDragState: groupedDragState)
+        moveControllerToTopOfStack(controller)
+        DispatchQueue.main.async { [weak self, weak controller] in
+            guard let self = self,
+                  let controller = controller,
+                  prefs.groupRulers,
+                  self.activeRulerID == controller.state.id else {
+                return
+            }
+
+            self.moveControllerToTopOfStack(controller)
+        }
         self.groupedDragState = nil
         notifyStateChanged()
     }
@@ -1888,6 +1902,22 @@ final class RulerManager {
         }
     }
 
+    private func moveControllerToTopOfStack(_ controller: RulerController) {
+        if let index = controllers.firstIndex(where: { $0 === controller }),
+           index != controllers.index(before: controllers.endIndex) {
+            controllers.remove(at: index)
+            controllers.append(controller)
+        }
+
+        if controller.isVisible {
+            controller.rulerWindow.orderFrontRegardless()
+            for otherController in controllers where otherController !== controller && otherController.isVisible {
+                controller.rulerWindow.order(.above, relativeTo: otherController.rulerWindow.windowNumber)
+                otherController.rulerWindow.order(.below, relativeTo: controller.rulerWindow.windowNumber)
+            }
+        }
+    }
+
     private func attachGroupedDragFollowers(
         to draggedController: RulerController,
         visibleControllers: [RulerController]
@@ -1923,6 +1953,9 @@ final class RulerManager {
                   followerController.rulerWindow.parent === draggedWindow else { continue }
 
             draggedWindow.removeChildWindow(followerController.rulerWindow)
+            if draggedController.isVisible, followerController.isVisible {
+                followerController.rulerWindow.order(.below, relativeTo: draggedWindow.windowNumber)
+            }
         }
     }
 

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -290,6 +290,43 @@ final class RulerCoreTests: XCTestCase {
         }
     }
 
+    func testRulerManagerMovesGroupedActiveRulerToTopOfStack() {
+        withRestoredRulerPreferences {
+            prefs.groupRulers = true
+            let manager = RulerManager()
+            let first = manager.createRuler(
+                defaults: RulerSettings(unit: .pixels),
+                screenFrame: NSRect(x: 0, y: 0, width: 1000, height: 800)
+            )
+            let second = manager.createRuler(
+                defaults: RulerSettings(unit: .inches),
+                screenFrame: NSRect(x: 0, y: 0, width: 1000, height: 800)
+            )
+            defer {
+                first.hide()
+                second.hide()
+            }
+            first.show()
+            second.show()
+
+            XCTAssertTrue(manager.controllers.last === second)
+
+            manager.markActive(first)
+
+            XCTAssertTrue(manager.activeController === first)
+            XCTAssertTrue(manager.controllers.last === first)
+
+            manager.beginGroupedDrag(from: first)
+            XCTAssertTrue(first.rulerWindow.childWindows?.contains(second.rulerWindow) ?? false)
+
+            manager.finishGroupedDrag(from: first)
+
+            XCTAssertFalse(first.rulerWindow.childWindows?.contains(second.rulerWindow) ?? false)
+            XCTAssertNil(second.rulerWindow.parent)
+            XCTAssertTrue(manager.controllers.last === first)
+        }
+    }
+
     func testRulerManagerCyclesVisibleRulers() {
         let manager = RulerManager()
         let first = manager.createRuler()


### PR DESCRIPTION
## Summary
- Promote the clicked grouped ruler to the end of the manager stack when it becomes active.
- Keep that active ruler above grouped followers when grouped drag child windows detach.
- Add a regression test for grouped active-ruler stacking across selection and drag finish.

## Root Cause
Grouped dragging temporarily attaches follower rulers as child windows. When those followers detach at the end of the drag, AppKit can restack them above the dragged ruler even though the dragged ruler was active during the drag.

## Checks
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests/RulerCoreTests/testRulerManagerMovesGroupedActiveRulerToTopOfStack`
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests`
- `git diff --check`

Closes #268