### PR TITLE
Suspend arrow keys while ruler settings are open

### DIFF
--- a/Free Ruler/PreferencesController.swift
+++ b/Free Ruler/PreferencesController.swift
@@ -892,6 +892,7 @@ final class RulerSettingsWindow: NSPanel {
 final class RulerSettingsController: NSWindowController, NSWindowDelegate {
 
     private weak var rulerController: RulerController?
+    private weak var interactionSuspendedRulerController: RulerController?
     private var colorPanelObserver: NSObjectProtocol?
     private var didConfigureWindow = false
 
@@ -997,6 +998,7 @@ final class RulerSettingsController: NSWindowController, NSWindowDelegate {
     }
 
     deinit {
+        clearRulerInteractionSuspension()
         if let colorPanelObserver = colorPanelObserver {
             NotificationCenter.default.removeObserver(colorPanelObserver)
         }
@@ -1009,6 +1011,7 @@ final class RulerSettingsController: NSWindowController, NSWindowDelegate {
         window?.makeKeyAndOrderFront(sender)
         window?.makeFirstResponder(unitSegmentedControl)
         window?.center()
+        updateRulerInteractionSuspension()
     }
 
     func show(attachedTo controller: RulerController, sender: Any?) {
@@ -1022,6 +1025,7 @@ final class RulerSettingsController: NSWindowController, NSWindowDelegate {
             settingsWindow.orderFront(sender)
             settingsWindow.makeKey()
             settingsWindow.makeFirstResponder(unitSegmentedControl)
+            updateRulerInteractionSuspension()
             return
         }
 
@@ -1041,9 +1045,11 @@ final class RulerSettingsController: NSWindowController, NSWindowDelegate {
         settingsWindow.orderFront(sender)
         settingsWindow.makeKey()
         settingsWindow.makeFirstResponder(unitSegmentedControl)
+        updateRulerInteractionSuspension()
     }
 
     override func close() {
+        clearRulerInteractionSuspension()
         detachWindowIfNeeded()
         super.close()
     }
@@ -1053,12 +1059,14 @@ final class RulerSettingsController: NSWindowController, NSWindowDelegate {
     }
 
     func windowWillClose(_ notification: Notification) {
+        clearRulerInteractionSuspension()
         detachWindowIfNeeded()
         closeSheetColorControls()
     }
 
     func updateRulerController(_ controller: RulerController) {
         rulerController = controller
+        updateRulerInteractionSuspension()
         updateView()
     }
 
@@ -1278,6 +1286,25 @@ final class RulerSettingsController: NSWindowController, NSWindowDelegate {
         if colorPanel.parent === settingsWindow {
             position(colorPanel, attachedTo: settingsWindow)
         }
+    }
+
+    private func updateRulerInteractionSuspension() {
+        guard window?.isVisible == true,
+              let controller = rulerController else {
+            clearRulerInteractionSuspension()
+            return
+        }
+
+        guard interactionSuspendedRulerController !== controller else { return }
+
+        clearRulerInteractionSuspension()
+        controller.suspendRulerInteraction(owner: self)
+        interactionSuspendedRulerController = controller
+    }
+
+    private func clearRulerInteractionSuspension() {
+        interactionSuspendedRulerController?.resumeRulerInteraction(owner: self)
+        interactionSuspendedRulerController = nil
     }
 
     private func applySettings(_ update: (inout RulerSettings) -> Void) {

--- a/Free Ruler/RulerWindow.swift
+++ b/Free Ruler/RulerWindow.swift
@@ -1145,19 +1145,16 @@ final class RulerController: NSWindowController, NSWindowDelegate, NotificationO
     private var keyListener: Any?
     private var mouseInteraction: RulerMouseInteractionState!
     private var isMouseTickDrawingEnabled = true
+    private let rulerInteractionSuspensionOwners = NSHashTable<AnyObject>.weakObjects()
     private let followsDefaultPreferences: Bool
 
     var isLeftMouseButtonPressed = {
         return NSEvent.pressedMouseButtons & 1 == 1
     }
 
-    var preferencesWindowOpen = false {
-        didSet {
-            updateIsFloatingPanel()
-            if !preferencesWindowOpen {
-                opacity = state.settings.foregroundOpacity
-            }
-        }
+    var isRulerInteractionSuspended: Bool {
+        guard rulerInteractionSuspensionOwners.count > 0 else { return false }
+        return rulerInteractionSuspensionOwners.anyObject != nil
     }
 
     var opacity = 0 {
@@ -1314,8 +1311,26 @@ final class RulerController: NSWindowController, NSWindowDelegate, NotificationO
         opacity = state.settings.backgroundOpacity
     }
 
+    func suspendRulerInteraction(owner: AnyObject) {
+        guard !rulerInteractionSuspensionOwners.contains(owner) else { return }
+
+        rulerInteractionSuspensionOwners.add(owner)
+        updateIsFloatingPanel()
+    }
+
+    func resumeRulerInteraction(owner: AnyObject) {
+        guard rulerInteractionSuspensionOwners.contains(owner) else { return }
+
+        rulerInteractionSuspensionOwners.remove(owner)
+        updateIsFloatingPanel()
+
+        if !isRulerInteractionSuspended {
+            opacity = state.settings.foregroundOpacity
+        }
+    }
+
     func updateIsFloatingPanel() {
-        rulerWindow.isFloatingPanel = preferencesWindowOpen ? false : state.settings.floatRulers
+        rulerWindow.isFloatingPanel = isRulerInteractionSuspended ? false : state.settings.floatRulers
     }
 
     func updateHasShadow() {
@@ -1521,11 +1536,13 @@ final class RulerController: NSWindowController, NSWindowDelegate, NotificationO
 
     private func createObservers() {
         notificationObservers = [
-            addObserver(.preferencesWindowOpened) { [weak self] _ in
-                self?.preferencesWindowOpen = true
+            addObserver(.preferencesWindowOpened) { [weak self] notification in
+                guard let owner = notification.object else { return }
+                self?.suspendRulerInteraction(owner: owner as AnyObject)
             },
-            addObserver(.preferencesWindowClosed) { [weak self] _ in
-                self?.preferencesWindowOpen = false
+            addObserver(.preferencesWindowClosed) { [weak self] notification in
+                guard let owner = notification.object else { return }
+                self?.resumeRulerInteraction(owner: owner as AnyObject)
             },
         ]
     }
@@ -1574,8 +1591,10 @@ extension RulerController {
         let shift = event.modifierFlags.contains(.shift)
         let keyboardModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
-        if rulerWindow.isKeyWindow,
-           let appDelegate = NSApp.delegate as? AppDelegate,
+        guard !isRulerInteractionSuspended,
+              rulerWindow.isKeyWindow else { return event }
+
+        if let appDelegate = NSApp.delegate as? AppDelegate,
            appDelegate.performRulerHotkey(
                keyCode: Int(event.keyCode),
                modifierFlags: keyboardModifiers,

--- a/FreeRulerTests/RulerCoreTests.swift
+++ b/FreeRulerTests/RulerCoreTests.swift
@@ -1070,6 +1070,86 @@ final class RulerCoreTests: XCTestCase {
         XCTAssertNil(settingsWindow.sheetParent)
     }
 
+    func testRulerSettingsControllerSuspendsOnlyAttachedRulerWhileVisible() {
+        let first = RulerController(
+            state: RulerInstanceState(
+                settings: RulerSettings(floatRulers: true),
+                layout: RulerLayoutState(
+                    zeroPoint: NSPoint(x: 240, y: 320),
+                    horizontalLength: 260,
+                    verticalLength: 180
+                )
+            )
+        )
+        let second = RulerController(
+            state: RulerInstanceState(
+                settings: RulerSettings(floatRulers: true),
+                layout: RulerLayoutState(
+                    zeroPoint: NSPoint(x: 540, y: 320),
+                    horizontalLength: 260,
+                    verticalLength: 180
+                )
+            )
+        )
+        let settingsController = RulerSettingsController(rulerController: first)
+        defer {
+            settingsController.close()
+            first.hide()
+            second.hide()
+        }
+
+        first.show()
+        second.show()
+
+        settingsController.show(attachedTo: first, sender: self)
+
+        XCTAssertTrue(first.isRulerInteractionSuspended)
+        XCTAssertFalse(second.isRulerInteractionSuspended)
+        XCTAssertFalse(first.rulerWindow.isFloatingPanel)
+        XCTAssertTrue(second.rulerWindow.isFloatingPanel)
+
+        settingsController.show(attachedTo: second, sender: self)
+
+        XCTAssertFalse(first.isRulerInteractionSuspended)
+        XCTAssertTrue(second.isRulerInteractionSuspended)
+        XCTAssertTrue(first.rulerWindow.isFloatingPanel)
+        XCTAssertFalse(second.rulerWindow.isFloatingPanel)
+
+        settingsController.close()
+
+        XCTAssertFalse(first.isRulerInteractionSuspended)
+        XCTAssertFalse(second.isRulerInteractionSuspended)
+        XCTAssertTrue(first.rulerWindow.isFloatingPanel)
+        XCTAssertTrue(second.rulerWindow.isFloatingPanel)
+    }
+
+    func testRulerControllerPassesArrowKeysThroughWhileInteractionSuspended() {
+        let controller = RulerController(
+            state: RulerInstanceState(
+                settings: RulerSettings(),
+                layout: RulerLayoutState(
+                    zeroPoint: NSPoint(x: 240, y: 320),
+                    horizontalLength: 260,
+                    verticalLength: 180
+                )
+            )
+        )
+        let owner = NSObject()
+        defer {
+            controller.resumeRulerInteraction(owner: owner)
+            controller.hide()
+        }
+
+        let event = keyDownEvent(characters: "", keyCode: UInt16(kVK_RightArrow))
+        let initialFrame = controller.rulerWindow.frame
+
+        controller.suspendRulerInteraction(owner: owner)
+
+        XCTAssertTrue(controller.isRulerInteractionSuspended)
+        XCTAssertTrue(controller.onKeyDown(with: event) === event)
+        XCTAssertEqual(controller.rulerWindow.frame, initialFrame)
+    }
+
     func testRulerSettingsControllerAnchorsPanelCornerToRulerZeroPoint() {
         let visibleFrame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1200, height: 900)
         let zeroPoint = NSPoint(x: visibleFrame.midX, y: visibleFrame.midY)


### PR DESCRIPTION
Fixes #272.

## Summary
- Replaced the stale `preferencesWindowOpen` boolean with owner-tracked ruler interaction suspension.
- Suspended only the ruler attached to the per-ruler Settings panel, and moved that suspension when the reusable panel switches rulers.
- Let arrow-key events pass through while ruler interaction is suspended or the ruler window is not key, so settings controls can handle navigation.

## Root Cause
The previous state model only represented the global Preferences window. After multiple rulers and the per-ruler Settings panel were introduced, the key listener could still consume arrow keys for ruler nudging while the Settings panel was open.

## Validation
- `xcodebuild -project "Free Ruler.xcodeproj" -scheme "Free Ruler" test -only-testing:FreeRulerTests`
- `git diff --check`